### PR TITLE
Validate wire plugin_version at the agent boundary (SEC-2)

### DIFF
--- a/crates/agent/src/catalog.rs
+++ b/crates/agent/src/catalog.rs
@@ -18,7 +18,7 @@ pub enum ResolveError {
     #[error("invalid plugin name: {0}")]
     Name(#[from] PluginNameError),
     /// The wire `plugin_version` is not path-safe (charset `[A-Za-z0-9._+-]`).
-    #[error("invalid plugin version: {0}")]
+    #[error("invalid plugin version: {0:?}")]
     Version(String),
     /// No catalog entry directory exists for `<name>@<version>`.
     #[error("plugin not in catalog: {0}")]

--- a/crates/agent/src/catalog.rs
+++ b/crates/agent/src/catalog.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use faultforge_fault::catalog::{CatalogError, load_plugin, plugin_dir_name};
 use faultforge_fault::digest::Digest;
-use faultforge_fault::manifest::{Manifest, PluginName, PluginNameError};
+use faultforge_fault::manifest::{Manifest, PluginName, PluginNameError, is_valid_plugin_version};
 
 /// Why a plugin could not be resolved and verified from the catalog.
 #[derive(Debug, thiserror::Error)]
@@ -17,6 +17,9 @@ pub enum ResolveError {
     /// The wire `plugin_name` is not a valid catalog name.
     #[error("invalid plugin name: {0}")]
     Name(#[from] PluginNameError),
+    /// The wire `plugin_version` is not path-safe (charset `[A-Za-z0-9._+-]`).
+    #[error("invalid plugin version: {0}")]
+    Version(String),
     /// No catalog entry directory exists for `<name>@<version>`.
     #[error("plugin not in catalog: {0}")]
     NotFound(String),
@@ -58,6 +61,13 @@ pub fn resolve_verified(
     expected: &Digest,
 ) -> Result<VerifiedPlugin, ResolveError> {
     let name = PluginName::parse(name)?;
+    // SEC-2: the on-disk manifest charset is enforced at load time, but the wire
+    // `plugin_version` reaches `plugin_dir_name` unvalidated — a rogue master
+    // could send `1/../../../../tmp/evil` to escape `plugin_root`. Reject it with
+    // the manifest's own predicate before any filesystem join.
+    if !is_valid_plugin_version(version) {
+        return Err(ResolveError::Version(version.to_owned()));
+    }
     let dir = plugin_root.join(plugin_dir_name(&name, version));
     if !dir.is_dir() {
         return Err(ResolveError::NotFound(dir.display().to_string()));
@@ -138,6 +148,19 @@ mod tests {
         assert!(matches!(
             resolve_verified(root.path(), "fixture", "1", &digest),
             Err(ResolveError::DigestMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn traversal_version_is_rejected_before_filesystem_join() {
+        let root = tempfile::tempdir().unwrap();
+        // A valid entry is installed so the version gate must be what rejects the
+        // request — not a missing directory (SEC-2: a rogue master's
+        // `plugin_version` climbing out of the catalog must never reach the join).
+        let digest = install(root.path());
+        assert!(matches!(
+            resolve_verified(root.path(), "fixture", "1/../../../../tmp/evil", &digest),
+            Err(ResolveError::Version(_))
         ));
     }
 

--- a/crates/agent/src/supervisor.rs
+++ b/crates/agent/src/supervisor.rs
@@ -612,7 +612,13 @@ async fn run_instance(
     };
     let (env, initial_event) = match setup_result {
         Ok(Ok((_plugin, params))) => (InstanceEnv { params, ..env }, Event::SetupOk),
-        Ok(Err(reason)) => (env, Event::SetupFailed { reason }),
+        Ok(Err(reason)) => {
+            // The reason also rides the Error `InstanceStatus` to the master, but a
+            // local log makes a rejected RunFault visible on the host even with the
+            // master link down — notably a SEC-2 version rejection before any join.
+            warn!(instance_id = %env.id, reason = %reason, "setup rejected RunFault");
+            (env, Event::SetupFailed { reason })
+        }
         Err(join_err) => (
             env,
             Event::SetupFailed {

--- a/crates/agent/src/supervisor.rs
+++ b/crates/agent/src/supervisor.rs
@@ -616,7 +616,7 @@ async fn run_instance(
             // The reason also rides the Error `InstanceStatus` to the master, but a
             // local log makes a rejected RunFault visible on the host even with the
             // master link down — notably a SEC-2 version rejection before any join.
-            warn!(instance_id = %env.id, reason = %reason, "setup rejected RunFault");
+            warn!(instance_id = %env.id, reason = ?reason, "setup rejected RunFault");
             (env, Event::SetupFailed { reason })
         }
         Err(join_err) => (

--- a/crates/fault/src/manifest.rs
+++ b/crates/fault/src/manifest.rs
@@ -112,6 +112,23 @@ pub enum ManifestError {
     ZeroDuration,
 }
 
+/// Returns whether `version` is a path-safe plugin version: every byte is in
+/// the charset `[A-Za-z0-9._+-]`.
+///
+/// `<name>@<version>` feeds the catalog directory name (`plugin_dir_name`), so a
+/// path separator or other unsafe character would let the identity escape the
+/// catalog root. This is the single source of truth for the version charset:
+/// [`Manifest::validate`] enforces it on the on-disk manifest, and the agent
+/// enforces the same rule on the wire `plugin_version` (SEC-2) before any
+/// filesystem join. Note that an empty string satisfies this predicate; callers
+/// that require a non-empty version must check that separately.
+#[must_use]
+pub fn is_valid_plugin_version(version: &str) -> bool {
+    version
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'+' | b'-'))
+}
+
 /// The raw, shape-only manifest as deserialized from YAML, before semantic
 /// validation. Private so the only way to obtain a public [`Manifest`] from YAML
 /// is [`Manifest::parse`], which validates — deserializing cannot bypass the
@@ -201,11 +218,7 @@ impl Manifest {
         if self.version.is_empty() {
             return Err(ManifestError::VersionEmpty);
         }
-        if !self
-            .version
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'+' | b'-'))
-        {
+        if !is_valid_plugin_version(&self.version) {
             return Err(ManifestError::VersionInvalidChar(self.version.clone()));
         }
         if self.max_duration_secs == 0 {


### PR DESCRIPTION
## Summary

A rogue master could send a `plugin_version` like `1/../../../../tmp/evil` to climb out of `plugin_root` and execute attacker-staged bytes as root. The on-disk manifest charset is enforced at load time, but the wire value reached `plugin_dir_name` unvalidated.

## Changes

- Extract the version charset check (`[A-Za-z0-9._+-]`), previously inlined in `Manifest::validate`, into a public `faultforge_fault::manifest::is_valid_plugin_version` — the single source of truth reused by both the manifest and the agent (no copied regex).
- Gate `resolve_verified` (agent catalog) with that predicate before any filesystem join. Placing it there covers both call sites (`setup` and the per-invocation re-verify) plus replay, so no caller can bypass it.
- Log a local `warn!` when `setup` rejects a `RunFault`, so a rejected request is visible on the host even with the master link down.
- Unit test: a traversal payload with a valid entry installed is rejected as `ResolveError::Version` before the filesystem join (proves no spawn).

## Verification

`cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)