### PR TITLE
refactor(master): centralize mutex-poison lock policy in one helper

### DIFF
--- a/crates/master/src/dispatch.rs
+++ b/crates/master/src/dispatch.rs
@@ -21,6 +21,7 @@ use crate::experiment::{
     Cause, DEADLINE_MARGIN_MS, Experiment, ExperimentDefinition, ExperimentId, ExperimentPhase,
     HostFacts, ValidationFailure, mint_experiment, validate,
 };
+use crate::lock::lock_poison_free;
 use crate::registry::{Registry, set_taint};
 use crate::sessions::SessionMap;
 
@@ -108,9 +109,7 @@ impl Dispatcher {
     }
 
     fn lock_store(&self) -> std::sync::MutexGuard<'_, HashMap<ExperimentId, Experiment>> {
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        self.store.lock().expect("experiment store lock poisoned")
+        lock_poison_free(&self.store)
     }
 
     // ===== Accept path (design D5, single salvo) =====
@@ -150,9 +149,7 @@ impl Dispatcher {
     }
 
     fn gather_host_facts(&self, definition: &ExperimentDefinition) -> HashMap<String, HostFacts> {
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        let registry = self.registry.lock().expect("registry lock poisoned");
+        let registry = lock_poison_free(&self.registry);
         let mut facts = HashMap::new();
         for action in &definition.actions {
             for host in &action.hosts {
@@ -401,9 +398,7 @@ impl Dispatcher {
     /// Panics if the registry mutex is poisoned.
     pub async fn clear_taint(&self, hostname: &Hostname) -> ClearTaintOutcome {
         {
-            #[allow(clippy::expect_used)]
-            // mutex poison means a previous thread panicked; propagating is correct
-            let registry = self.registry.lock().expect("registry lock poisoned");
+            let registry = lock_poison_free(&self.registry);
             if !registry.contains_key(hostname) {
                 return ClearTaintOutcome::UnknownHost;
             }

--- a/crates/master/src/lib.rs
+++ b/crates/master/src/lib.rs
@@ -5,6 +5,7 @@ pub mod clock;
 pub mod config;
 pub mod dispatch;
 pub mod experiment;
+mod lock;
 pub mod management;
 pub mod registry;
 mod server;

--- a/crates/master/src/lock.rs
+++ b/crates/master/src/lock.rs
@@ -1,0 +1,16 @@
+//! The single home for the master's mutex-lock policy (issue #25): one helper
+//! so the `expect`-on-poison rationale lives in exactly one place instead of
+//! being copy-pasted at every lock site.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Locks `mutex`, propagating a poisoned lock by panicking.
+///
+/// # Panics
+///
+/// Panics if the lock is poisoned.
+#[allow(clippy::expect_used)]
+// mutex poison means a previous thread panicked; propagating is correct
+pub(crate) fn lock_poison_free<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().expect("lock poisoned")
+}

--- a/crates/master/src/lock.rs
+++ b/crates/master/src/lock.rs
@@ -9,8 +9,11 @@ use std::sync::{Mutex, MutexGuard};
 /// # Panics
 ///
 /// Panics if the lock is poisoned.
+#[track_caller]
 #[allow(clippy::expect_used)]
 // mutex poison means a previous thread panicked; propagating is correct
 pub(crate) fn lock_poison_free<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().expect("lock poisoned")
+    mutex
+        .lock()
+        .expect("mutex poisoned: a previous holder panicked while holding this lock; propagating the panic is the correct fail-fast response")
 }

--- a/crates/master/src/management.rs
+++ b/crates/master/src/management.rs
@@ -25,6 +25,7 @@ use crate::experiment::{
     Cause, Experiment, ExperimentDefinition, ExperimentId, ExperimentOutcome, ExperimentPhase,
     InstanceRecord,
 };
+use crate::lock::lock_poison_free;
 use crate::registry::{AgentInfo, Registry};
 
 // ===== Agent views =====
@@ -196,12 +197,7 @@ pub struct ManagementState {
 /// `GET /agents` — list every registered agent as a JSON array (empty when none).
 #[allow(clippy::needless_pass_by_value)] // axum requires extractors taken by value
 async fn list_agents(State(state): State<ManagementState>) -> Json<Vec<AgentView>> {
-    #[allow(clippy::expect_used)]
-    // mutex poison means a previous thread panicked; propagating is correct
-    let views = state
-        .registry
-        .lock()
-        .expect("registry lock poisoned")
+    let views = lock_poison_free(&state.registry)
         .values()
         .map(agent_view)
         .collect();
@@ -218,12 +214,7 @@ async fn get_agent(
     Path(hostname): Path<String>,
 ) -> Result<Json<AgentView>, StatusCode> {
     let hostname = Hostname::parse(&hostname).map_err(|_| StatusCode::NOT_FOUND)?;
-    #[allow(clippy::expect_used)]
-    // mutex poison means a previous thread panicked; propagating is correct
-    let view = state
-        .registry
-        .lock()
-        .expect("registry lock poisoned")
+    let view = lock_poison_free(&state.registry)
         .get(&hostname)
         .map(agent_view);
     view.map(Json).ok_or(StatusCode::NOT_FOUND)

--- a/crates/master/src/registry.rs
+++ b/crates/master/src/registry.rs
@@ -4,6 +4,8 @@ use std::time::SystemTime;
 
 use faultforge_proto::Hostname;
 
+use crate::lock::lock_poison_free;
+
 #[derive(Debug, Clone)]
 pub struct AgentInfo {
     pub hostname: Hostname,
@@ -27,9 +29,7 @@ pub fn new_registry() -> Registry {
 ///
 /// Panics if the registry mutex is poisoned.
 pub fn register_agent(registry: &Registry, hostname: &Hostname, now: SystemTime) {
-    #[allow(clippy::expect_used)]
-    // mutex poison means a previous thread panicked; propagating is correct
-    let mut reg = registry.lock().expect("registry lock poisoned");
+    let mut reg = lock_poison_free(registry);
     // Re-registration must not read as "clean" before the agent's own
     // TaintStatus arrives moments later — carry the last known quarantine over.
     let tainted = reg.get(hostname).is_some_and(|info| info.tainted);
@@ -50,13 +50,7 @@ pub fn register_agent(registry: &Registry, hostname: &Hostname, now: SystemTime)
 ///
 /// Panics if the registry mutex is poisoned.
 pub fn set_taint(registry: &Registry, hostname: &Hostname, tainted: bool) {
-    #[allow(clippy::expect_used)]
-    // mutex poison means a previous thread panicked; propagating is correct
-    if let Some(entry) = registry
-        .lock()
-        .expect("registry lock poisoned")
-        .get_mut(hostname)
-    {
+    if let Some(entry) = lock_poison_free(registry).get_mut(hostname) {
         entry.tainted = tainted;
     }
 }
@@ -69,13 +63,7 @@ pub fn set_taint(registry: &Registry, hostname: &Hostname, tainted: bool) {
 ///
 /// Panics if the registry mutex is poisoned.
 pub fn update_heartbeat(registry: &Registry, hostname: &Hostname, now: SystemTime) {
-    #[allow(clippy::expect_used)]
-    // mutex poison means a previous thread panicked; propagating is correct
-    if let Some(entry) = registry
-        .lock()
-        .expect("registry lock poisoned")
-        .get_mut(hostname)
-    {
+    if let Some(entry) = lock_poison_free(registry).get_mut(hostname) {
         entry.last_seen = now;
     }
 }

--- a/crates/master/src/sessions.rs
+++ b/crates/master/src/sessions.rs
@@ -13,6 +13,8 @@ use tonic::Status;
 use faultforge_proto::Hostname;
 use faultforge_proto::v1::ServerMessage;
 
+use crate::lock::lock_poison_free;
+
 /// The outbound half of one agent's `Session` stream.
 pub type SessionTx = mpsc::Sender<Result<ServerMessage, Status>>;
 
@@ -35,12 +37,7 @@ impl SessionMap {
     /// Panics if the map mutex is poisoned.
     pub fn insert(&self, hostname: &Hostname, tx: SessionTx) -> u64 {
         let epoch = self.epochs.fetch_add(1, Ordering::Relaxed);
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        self.inner
-            .lock()
-            .expect("session map lock poisoned")
-            .insert(hostname.clone(), (epoch, tx));
+        lock_poison_free(&self.inner).insert(hostname.clone(), (epoch, tx));
         epoch
     }
 
@@ -51,9 +48,7 @@ impl SessionMap {
     ///
     /// Panics if the map mutex is poisoned.
     pub fn remove_if_current(&self, hostname: &Hostname, epoch: u64) {
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        let mut inner = self.inner.lock().expect("session map lock poisoned");
+        let mut inner = lock_poison_free(&self.inner);
         if inner.get(hostname).is_some_and(|(e, _)| *e == epoch) {
             inner.remove(hostname);
         }
@@ -66,11 +61,7 @@ impl SessionMap {
     /// Panics if the map mutex is poisoned.
     #[must_use]
     pub fn sender(&self, hostname: &Hostname) -> Option<SessionTx> {
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        self.inner
-            .lock()
-            .expect("session map lock poisoned")
+        lock_poison_free(&self.inner)
             .get(hostname)
             .map(|(_, tx)| tx.clone())
     }
@@ -82,12 +73,7 @@ impl SessionMap {
     /// Panics if the map mutex is poisoned.
     #[must_use]
     pub fn is_connected(&self, hostname: &Hostname) -> bool {
-        #[allow(clippy::expect_used)]
-        // mutex poison means a previous thread panicked; propagating is correct
-        self.inner
-            .lock()
-            .expect("session map lock poisoned")
-            .contains_key(hostname)
+        lock_poison_free(&self.inner).contains_key(hostname)
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the ~12 copy-pasted `#[allow(clippy::expect_used)]` + WHY-comment + `.lock().expect(...)` triples across the master crate with a single `lock_poison_free<T>(&Mutex<T>) -> MutexGuard<'_, T>` helper.

The helper lives in a new `crates/master/src/lock.rs`. The expect-on-poison rationale (a poisoned lock means a previous thread panicked, so propagating the panic is correct) now sits at exactly one `#[allow]` site instead of being repeated at every lock.

## Call sites collapsed (12)
- `registry.rs` — 3
- `sessions.rs` — 4
- `dispatch.rs` — 3
- `management.rs` — 2

## Behavior
Unchanged: locking a poisoned mutex still panics/propagates. `#[cfg(test)]` `.lock().unwrap()` calls are test-exempt and left untouched.

## Verification
- `cargo build --workspace` — clean
- `cargo test --workspace` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `rg "mutex poison" crates/master/src` — single `#[allow]` site (in `lock.rs`)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)