### PR TITLE
Downgrade per-heartbeat log and sort GET /agents by hostname

### DIFF
--- a/crates/master/src/management.rs
+++ b/crates/master/src/management.rs
@@ -198,13 +198,16 @@ pub struct ManagementState {
 async fn list_agents(State(state): State<ManagementState>) -> Json<Vec<AgentView>> {
     #[allow(clippy::expect_used)]
     // mutex poison means a previous thread panicked; propagating is correct
-    let views = state
+    let mut views: Vec<AgentView> = state
         .registry
         .lock()
         .expect("registry lock poisoned")
         .values()
         .map(agent_view)
         .collect();
+    // Stable, hostname-sorted order: HashMap iteration is nondeterministic, so
+    // without this the fleet view and CLI reshuffle between requests.
+    views.sort_by(|a, b| a.hostname.cmp(&b.hostname));
     Json(views)
 }
 
@@ -403,5 +406,27 @@ mod tests {
         let clone = state.clone();
         assert!(Arc::ptr_eq(&state.registry, &clone.registry));
         assert!(Arc::ptr_eq(&state.dispatcher, &clone.dispatcher));
+    }
+
+    #[tokio::test]
+    async fn list_agents_returns_hostname_sorted_order() {
+        let registry = new_registry();
+        let now = UNIX_EPOCH + Duration::from_secs(1);
+        for host in ["web-03", "web-01", "web-02"] {
+            crate::registry::register_agent(&registry, &Hostname::parse(host).unwrap(), now);
+        }
+        let dispatcher = Arc::new(Dispatcher::new(
+            crate::catalog::Catalog::default(),
+            Arc::clone(&registry),
+            10,
+            Arc::new(crate::clock::SystemClock),
+        ));
+        let state = ManagementState {
+            registry,
+            dispatcher,
+        };
+        let Json(views) = list_agents(State(state)).await;
+        let hostnames: Vec<&str> = views.iter().map(|v| v.hostname.as_str()).collect();
+        assert_eq!(hostnames, ["web-01", "web-02", "web-03"]);
     }
 }

--- a/crates/master/src/session.rs
+++ b/crates/master/src/session.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 
 use tokio::sync::mpsc;
 use tonic::{Status, Streaming};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use faultforge_fault::proto::from_wire_i32;
 use faultforge_proto::Hostname;
@@ -158,7 +158,9 @@ impl Session {
             Ok(reply) => {
                 if let Some(h) = self.hostname.as_ref() {
                     update_heartbeat(self.dispatcher.registry(), h, now);
-                    info!(hostname = %h, "heartbeat");
+                    // debug, not info: at fleet scale (200 agents) the per-heartbeat
+                    // line floods default-level logs with ~40 lines/sec of noise.
+                    debug!(hostname = %h, "heartbeat");
                 }
                 self.send(reply).await
             }

--- a/crates/master/tests/management_api.rs
+++ b/crates/master/tests/management_api.rs
@@ -133,6 +133,29 @@ async fn management_api_exposes_registered_agent() {
 }
 
 #[tokio::test]
+async fn management_api_lists_agents_in_hostname_sorted_order() {
+    let (grpc_url, management_url, _registry) = start_servers().await;
+
+    for host in ["web-03", "web-01", "web-02"] {
+        register_agent_over_grpc(&grpc_url, host).await;
+    }
+
+    let list: Vec<serde_json::Value> = reqwest::Client::new()
+        .get(format!("{management_url}/agents"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let hostnames: Vec<&str> = list
+        .iter()
+        .map(|a| a["hostname"].as_str().unwrap())
+        .collect();
+    assert_eq!(hostnames, ["web-01", "web-02", "web-03"]);
+}
+
+#[tokio::test]
 async fn management_api_returns_empty_array_when_no_agents() {
     let (_grpc_url, management_url, _registry) = start_servers().await;
 


### PR DESCRIPTION
## Summary

Two small operability fixes (L4 / L10):

- **(a)** `crates/master/src/session.rs`: downgrade the per-heartbeat log from `info!` to `debug!`. At fleet scale (200 agents) it flooded default-level logs with ~40 lines/sec of noise.
- **(b)** `crates/master/src/management.rs` (`list_agents`): sort the `GET /agents` response by hostname ascending. `HashMap` iteration order is nondeterministic, which reshuffled the fleet view and CLI between requests. The `list_agents` change is kept to the sorting only (lock-acquisition line untouched) to minimize conflict with the in-flight lock-helper refactor.

## Tests

- Added a unit test (`list_agents_returns_hostname_sorted_order`) and an end-to-end management test (`management_api_lists_agents_in_hostname_sorted_order`) that register hosts out of order and assert sorted output.
- `cargo build`, `cargo test`, `cargo clippy -D warnings`, `cargo fmt --check` all pass.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)