### PR TITLE
docs: fix stale doc-comments and narration in CLI (#27)

### DIFF
--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -12,10 +12,6 @@ use crate::cli::OutputFormat;
 /// Render a list of agents in the chosen format.
 ///
 /// `now` is used to compute relative ages for table output; it is ignored for JSON.
-///
-/// # Errors
-///
-/// Returns an error if JSON serialisation fails (should be infallible for well-typed data).
 pub fn render_agents(agents: &[Agent], format: &OutputFormat, now: SystemTime) -> String {
     match format {
         OutputFormat::Json => render_agents_json(agents),
@@ -24,10 +20,6 @@ pub fn render_agents(agents: &[Agent], format: &OutputFormat, now: SystemTime) -
 }
 
 /// Render a single agent in the chosen format.
-///
-/// # Errors
-///
-/// Returns an error if JSON serialisation fails.
 pub fn render_agent(agent: &Agent, format: &OutputFormat, now: SystemTime) -> String {
     match format {
         OutputFormat::Json => render_agent_json(agent),

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -25,25 +25,12 @@ use model::{Effect, Model, Msg};
 /// Polling interval between automatic agent refreshes.
 const POLL_INTERVAL: Duration = Duration::from_secs(3);
 
-/// A handle to the crossterm key-reader thread.
-///
-/// The thread reads blocking key events and sends them through a channel.
-/// The handle joins the thread on drop.
-struct KeyReaderHandle(Option<std::thread::JoinHandle<()>>);
-
-impl Drop for KeyReaderHandle {
-    fn drop(&mut self) {
-        // The thread exits when the sender channel is closed (event loop dropped
-        // the receiver), so we just detach here to avoid a join block on exit.
-        if let Some(handle) = self.0.take() {
-            drop(handle);
-        }
-    }
-}
-
 /// Spawn a thread that reads crossterm events and sends key presses into `tx`.
-fn spawn_key_reader(tx: mpsc::UnboundedSender<Msg>) -> KeyReaderHandle {
-    let handle = std::thread::spawn(move || {
+///
+/// The returned handle is detached on drop; the thread exits on its own when
+/// the channel closes (the event loop dropped the receiver).
+fn spawn_key_reader(tx: mpsc::UnboundedSender<Msg>) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
         loop {
             match event::read() {
                 Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
@@ -56,8 +43,7 @@ fn spawn_key_reader(tx: mpsc::UnboundedSender<Msg>) -> KeyReaderHandle {
                 Err(_) => break,
             }
         }
-    });
-    KeyReaderHandle(Some(handle))
+    })
 }
 
 /// Launch the interactive TUI.

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -27,8 +27,11 @@ const POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Spawn a thread that reads crossterm events and sends key presses into `tx`.
 ///
-/// The returned handle is detached on drop; the thread exits on its own when
-/// the channel closes (the event loop dropped the receiver).
+/// The returned handle is detached on drop. The thread blocks in
+/// `event::read()`, so it does not observe a closed channel immediately: it
+/// stops only once `event::read()` errors, or once the next key event arrives
+/// and the follow-up `tx.send(...)` fails because the event loop dropped the
+/// receiver. Until then it can linger past the receiver.
 fn spawn_key_reader(tx: mpsc::UnboundedSender<Msg>) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         loop {

--- a/crates/cli/src/tui/update.rs
+++ b/crates/cli/src/tui/update.rs
@@ -15,7 +15,7 @@ use super::model::{Effect, Model, Msg};
 #[must_use]
 pub fn update(mut model: Model, msg: Msg, now: SystemTime) -> (Model, Option<Effect>) {
     match msg {
-        Msg::Key(key) => handle_key(model, key, now),
+        Msg::Key(key) => handle_key(model, key),
         Msg::Tick => {
             // Skip the periodic fetch if one is already in flight, so a slow or
             // hung master cannot pile up overlapping requests. A manual `r`
@@ -47,11 +47,7 @@ pub fn update(mut model: Model, msg: Msg, now: SystemTime) -> (Model, Option<Eff
     }
 }
 
-fn handle_key(
-    mut model: Model,
-    key: crossterm::event::KeyEvent,
-    now: SystemTime,
-) -> (Model, Option<Effect>) {
+fn handle_key(mut model: Model, key: crossterm::event::KeyEvent) -> (Model, Option<Effect>) {
     use KeyCode::{Char, Down, Up};
 
     if matches!(key.code, Char('q'))
@@ -73,7 +69,6 @@ fn handle_key(
         model.selected -= 1;
     }
 
-    let _ = now; // now is not used in key handling but kept for signature consistency
     (model, None)
 }
 

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -1,6 +1,6 @@
 //! Pure TUI view: build all four layout regions from the model.
 //!
-//! No I/O — `view` returns a closure that ratatui can render.
+//! No I/O — `view` renders directly into the frame ratatui provides.
 
 use std::time::SystemTime;
 


### PR DESCRIPTION
## What

Small, surgical doc/comment cleanups in the CLI crate where documentation had drifted from behaviour. No runtime behaviour change beyond removing a genuinely-unused parameter and a no-op `Drop`.

- **`crates/cli/src/output.rs`** — removed the `# Errors` doc sections on `render_agents` and `render_agent`. Both return `String` (serde failures are swallowed via `unwrap_or_else`), so an `# Errors` section is wrong.
- **`crates/cli/src/tui/view.rs`** — corrected the stale module doc claiming `view` "returns a closure"; it returns `()` and renders directly into the frame.
- **`crates/cli/src/tui/mod.rs`** — removed the no-op `KeyReaderHandle` `Drop` wrapper (dropping a `JoinHandle` already detaches, so the impl did nothing) and its misleading "joins the thread on drop" doc; `spawn_key_reader` now returns the `JoinHandle<()>` directly.
- **`crates/cli/src/tui/update.rs`** — dropped the unused `now` parameter from `handle_key` (and its CONVENTIONS §4 narration comment), updating the call site. `update` still takes `now` since other arms use it.

## Verification

`cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)