### PR TITLE
Guard preflight transition on the Preflight command kind (#24)

### DIFF
--- a/crates/agent/src/machine.rs
+++ b/crates/agent/src/machine.rs
@@ -345,12 +345,18 @@ fn step_preflight(which: Phase, stop: Option<StopCause>, event: Event) -> (State
             };
             aborted_with(format!("{phase_name} preflight: {}", describe(disposition)))
         }
-        Event::InvocationFailed { reason, .. } | Event::InvokeRejected { reason, .. } => {
-            aborted_with(format!("preflight invocation failed: {reason}"))
+        Event::InvocationFailed {
+            command: PluginCommand::Preflight,
+            reason,
         }
-        // Out-of-band events — a stray non-`Preflight` command, setup, or
-        // journal — cannot advance preflight: a confused shell must never
-        // crash an instance (issue #24). Absorb them, preserving `stop`.
+        | Event::InvokeRejected {
+            command: PluginCommand::Preflight,
+            reason,
+        } => aborted_with(format!("preflight invocation failed: {reason}")),
+        // Out-of-band events — a stray non-`Preflight` command's finish or
+        // failure, setup, or journal — cannot advance preflight: a confused
+        // shell must never crash an instance (issue #24). Absorb them,
+        // preserving `stop`.
         _ => (rebuild(stop), vec![]),
     }
 }
@@ -809,6 +815,50 @@ mod tests {
                 after_effects, before_effects,
                 "stray command must emit no new effects in {phase:?} preflight"
             );
+        }
+    }
+
+    #[test]
+    fn preflight_ignores_out_of_band_invocation_failure() {
+        // A failure or rejection of a non-`Preflight` command during preflight
+        // is an out-of-band signal: only the active preflight command failing
+        // may abort (issue #24). The instance must stay in preflight.
+        for phase in [Phase::Install, Phase::Runtime] {
+            let (base_events, expected_state) = match phase {
+                Phase::Install => (vec![Event::SetupOk], State::PreflightInstall { stop: None }),
+                Phase::Runtime => (
+                    vec![
+                        Event::SetupOk,
+                        finished(PluginCommand::Preflight, Disposition::Success),
+                    ],
+                    State::PreflightRuntime { stop: None },
+                ),
+            };
+            let (before_state, before_effects) = drive(base_events.clone());
+            assert_eq!(before_state, expected_state);
+
+            for stray in [
+                Event::InvocationFailed {
+                    command: PluginCommand::Cleanup,
+                    reason: "timeout".to_string(),
+                },
+                Event::InvokeRejected {
+                    command: PluginCommand::Cleanup,
+                    reason: "digest mismatch".to_string(),
+                },
+            ] {
+                let mut events = base_events.clone();
+                events.push(stray.clone());
+                let (after_state, after_effects) = drive(events);
+                assert_eq!(
+                    after_state, expected_state,
+                    "stray {stray:?} must leave {phase:?} preflight unchanged"
+                );
+                assert_eq!(
+                    after_effects, before_effects,
+                    "stray {stray:?} must emit no new effects in {phase:?} preflight"
+                );
+            }
         }
     }
 

--- a/crates/agent/src/machine.rs
+++ b/crates/agent/src/machine.rs
@@ -315,8 +315,8 @@ fn step_preflight(which: Phase, stop: Option<StopCause>, event: Event) -> (State
     match event {
         Event::StopRequested { cause } => (rebuild(stop.or(Some(cause))), vec![]),
         Event::CommandFinished {
+            command: PluginCommand::Preflight,
             disposition: Disposition::Success,
-            ..
         } => {
             if let Some(cause) = stop {
                 return aborted_with(format!("{}; never injected", cause.reason()));
@@ -335,7 +335,10 @@ fn step_preflight(which: Phase, stop: Option<StopCause>, event: Event) -> (State
                 ),
             }
         }
-        Event::CommandFinished { disposition, .. } => {
+        Event::CommandFinished {
+            command: PluginCommand::Preflight,
+            disposition,
+        } => {
             let phase_name = match which {
                 Phase::Install => "install",
                 Phase::Runtime => "runtime",
@@ -345,7 +348,9 @@ fn step_preflight(which: Phase, stop: Option<StopCause>, event: Event) -> (State
         Event::InvocationFailed { reason, .. } | Event::InvokeRejected { reason, .. } => {
             aborted_with(format!("preflight invocation failed: {reason}"))
         }
-        // Setup and journal events cannot occur here; ignore defensively.
+        // Out-of-band events — a stray non-`Preflight` command, setup, or
+        // journal — cannot advance preflight: a confused shell must never
+        // crash an instance (issue #24). Absorb them, preserving `stop`.
         _ => (rebuild(stop), vec![]),
     }
 }
@@ -774,6 +779,37 @@ mod tests {
             finished(PluginCommand::Preflight, Disposition::Unexpected(1)),
         ]);
         assert_eq!(state, State::Aborted);
+    }
+
+    #[test]
+    fn preflight_ignores_out_of_band_command() {
+        // A confused shell must never crash an instance: a finished command
+        // other than `Preflight` during preflight is ignored, not acted on.
+        for phase in [Phase::Install, Phase::Runtime] {
+            let (mut events, expected_state) = match phase {
+                Phase::Install => (vec![Event::SetupOk], State::PreflightInstall { stop: None }),
+                Phase::Runtime => (
+                    vec![
+                        Event::SetupOk,
+                        finished(PluginCommand::Preflight, Disposition::Success),
+                    ],
+                    State::PreflightRuntime { stop: None },
+                ),
+            };
+            let (before_state, before_effects) = drive(events.clone());
+            assert_eq!(before_state, expected_state);
+
+            events.push(finished(PluginCommand::Cleanup, Disposition::Success));
+            let (after_state, after_effects) = drive(events);
+            assert_eq!(
+                after_state, expected_state,
+                "stray command must leave {phase:?} preflight unchanged"
+            );
+            assert_eq!(
+                after_effects, before_effects,
+                "stray command must emit no new effects in {phase:?} preflight"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`step_preflight` accepted any `CommandFinished{Success}` regardless of which plugin command finished, unlike its siblings `step_recovering`/`step_injecting`, which pin the command kind. A stray non-`Preflight` `CommandFinished` (e.g. `CommandFinished{Cleanup, Success}`) could therefore advance the machine out of preflight, contradicting the "a confused shell can never crash an instance" invariant.

## Changes

- Add the `command: PluginCommand::Preflight` field pattern to **both** `CommandFinished` arms of `step_preflight`, mirroring the exact field-pattern guard style used by `step_injecting`. Guarding both arms is required: guarding only the Success arm would let a `CommandFinished{Cleanup, Success}` fall into the failure arm and abort. Out-of-band commands now fall through to the catch-all `_` arm and leave the instance state (and any pending `stop`) unchanged.
- Add a table-driven test `preflight_ignores_out_of_band_command` asserting that a `CommandFinished{Cleanup, Success}` during both preflight phases (Install and Runtime) does not advance the machine and emits no new effects.
- Extend the catch-all WHY comment to name the stray-command case.

## Verification

`cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)