### PR TITLE
Add disk-fill: the first host-mutating fault plugin (#62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Chaos-engineering platform for **bare-metal** hosts: a central **master** (contr
 
 ## Current state
 
-Cargo workspace, 6 crates:
+Cargo workspace, 7 crates:
 
 | Crate | Bin | Status | Role |
 |-------|-----|--------|------|
@@ -15,6 +15,7 @@ Cargo workspace, 6 crates:
 | `crates/agent` | `faultforge-agent` | **built (slice 2)** | Dials master with reconnect+backoff, register/heartbeat, and the **fault runtime**: executes fault instances from the on-disk catalog with a journal, safety timers, and taint quarantine |
 | `crates/cli` | `faultforge` | **built** | Operator CLI — one-shot scripting (`agents list/show/clear-taint`, `experiment run/list/show/halt`) + interactive TUI |
 | `crates/plugins/noop-marker` | `noop-marker` | **built** | Reference fault plugin: zero-blast-radius fault whose only effect is a marker file's existence. Proves the `faultforge-fault` contract with golden tests |
+| `crates/plugins/disk-fill` | `disk-fill` | **built** | First real (host-mutating) fault plugin: consumes free space by allocating `<fill_dir>/faultforge-<instance_id>.fill` — `fallocate(2)`, chunked-write fallback, `st_blocks`-verified so a sparse fill fails loudly. Hard headroom guarantee: refuses unless `size + max(5% capacity, 64 MiB)` stays free; warns (not refuses) on tmpfs, which fills RAM, not disk |
 | `crates/e2e` | — (tests) | **built (slice 4)** | Dev-only end-to-end harness (`faultforge-e2e`): builds container images and drives the **real** master/agent/CLI binaries as separate rootless-podman containers, asserting the fault lifecycle through the operator surface + host ground truth (`podman exec`). Never published; scenarios are `#[ignore]` so `cargo test --workspace` needs no podman |
 
 **Fault injection works end to end (`master-fault-dispatch`, slice 3).** The agent owns the full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "disk-fill"
+version = "0.1.0"
+dependencies = [
+ "faultforge-fault",
+ "humantime",
+ "rustix",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = [ "crates/agent", "crates/cli", "crates/e2e", "crates/fault", "crates/master", "crates/plugins/noop-marker", "crates/proto"]
+members = [ "crates/agent", "crates/cli", "crates/e2e", "crates/fault", "crates/master", "crates/plugins/disk-fill", "crates/plugins/noop-marker", "crates/proto"]
 
 [workspace.package]
 version = "0.1.0"
@@ -36,6 +36,8 @@ humantime = "2"
 # Runtime dep of noop-marker (preflight writability probe + atomic marker write)
 # and a dev-dep for catalog/plugin tests.
 tempfile = "3"
+# disk-fill's syscall surface (fallocate/statvfs/statfs) without unsafe blocks.
+rustix = { version = "1", features = ["fs"] }
 axum = "0.8"
 hostname = "0.4"
 thiserror = "2"

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -9,13 +9,15 @@ FROM docker.io/library/rust:1.96-bookworm AS builder
 WORKDIR /src
 # .containerignore keeps target/ and .git out of the context.
 COPY . .
-RUN cargo build --release -p faultforge-master -p faultforge-agent -p noop-marker
+RUN cargo build --release -p faultforge-master -p faultforge-agent -p noop-marker -p disk-fill
 
 # Assemble the on-disk catalog: <name>@<version>/{manifest.yaml, entrypoint}.
 RUN set -eux; \
-    mkdir -p /catalog/noop-marker@1 /catalog/hang-cleanup@1; \
+    mkdir -p /catalog/noop-marker@1 /catalog/disk-fill@1 /catalog/hang-cleanup@1; \
     cp crates/plugins/noop-marker/manifest.yaml   /catalog/noop-marker@1/manifest.yaml; \
     cp target/release/noop-marker                 /catalog/noop-marker@1/noop-marker; \
+    cp crates/plugins/disk-fill/manifest.yaml     /catalog/disk-fill@1/manifest.yaml; \
+    cp target/release/disk-fill                   /catalog/disk-fill@1/disk-fill; \
     cp containers/hang-cleanup/manifest.yaml      /catalog/hang-cleanup@1/manifest.yaml; \
     cp containers/hang-cleanup/hang-cleanup.sh    /catalog/hang-cleanup@1/hang-cleanup.sh; \
     chmod +x /catalog/hang-cleanup@1/hang-cleanup.sh

--- a/crates/e2e/tests/scenarios.rs
+++ b/crates/e2e/tests/scenarios.rs
@@ -159,6 +159,39 @@ fn agent_tainted(topo: &Topology) -> bool {
         .unwrap_or(false)
 }
 
+// ===== disk-fill helpers =====
+
+/// Experiment YAML for the disk-fill plugin, filling under the agent's data
+/// volume (guaranteed to exist and be agent-writable).
+fn disk_fill_yaml(name: &str, host: &str, size_mib: u64, duration_secs: u32) -> String {
+    format!(
+        "name: {name}\n\
+         actions:\n\
+         \x20 - hosts: [{host}]\n\
+         \x20   plugin: {{name: disk-fill, version: \"1\"}}\n\
+         \x20   params: {{fill_dir: {AGENT_DATA_DIR}, size_mib: {size_mib}}}\n\
+         \x20   duration_secs: {duration_secs}\n"
+    )
+}
+
+/// The deterministic fill-file path disk-fill derives for the single action of
+/// experiment `id` on `host` (`instance_id = <id>:<host>:0`).
+fn fill_file(id: &str, host: &str) -> String {
+    format!("{AGENT_DATA_DIR}/faultforge-{id}:{host}:0.fill")
+}
+
+/// `stat` the fill file inside the agent container: `(bytes, 512-blocks)`.
+fn agent_stat(topo: &Topology, path: &str) -> (u64, u64) {
+    let out = topo.agent_exec("0", &["stat", "-c", "%s %b", path]);
+    let mut parts = out.stdout.split_whitespace();
+    let size = parts.next().and_then(|s| s.parse().ok());
+    let blocks = parts.next().and_then(|s| s.parse().ok());
+    match (size, blocks) {
+        (Some(size), Some(blocks)) => (size, blocks),
+        _ => panic!("unparseable stat output for {path}: {:?}", out.stdout),
+    }
+}
+
 // ===== Scenario 3.1: happy path =====
 
 #[test]
@@ -401,4 +434,157 @@ fn taint_blocks_experiments_until_cleared() {
         "post-clear record:\n{}",
         run.stdout
     );
+}
+
+// ===== disk-fill: the first real host-mutating fault =====
+
+#[test]
+#[ignore = "requires rootless podman; run with -- --ignored"]
+fn disk_fill_happy_path_fills_exactly_and_cleans_up() {
+    let topo = Topology::start("dfhappy");
+    let size_mib: u64 = 16;
+    let yaml = disk_fill_yaml("df-happy-e2e", topo.agent_hostname(), size_mib, 5);
+    let yaml_path = write_yaml("dfhappy", &yaml);
+
+    // Drive `--wait` off-thread so the main thread can stat the fill file while
+    // the instance is ACTIVE. --wait's exit code is part of the test.
+    let url = topo.management_url().to_string();
+    let file_arg = yaml_path.to_string_lossy().into_owned();
+    let cli = std::thread::spawn(move || {
+        topology::run_cli(&url, &["experiment", "run", "-f", &file_arg, "--wait"])
+    });
+
+    let id = wait_for_experiment_id(&topo);
+    wait_for_instance_state(&topo, &id, "ACTIVE");
+    let fill = fill_file(&id, topo.agent_hostname());
+    assert!(
+        topo.agent_path_exists(&fill),
+        "fill file must exist while ACTIVE"
+    );
+    let (bytes, blocks) = agent_stat(&topo, &fill);
+    let size = size_mib * 1024 * 1024;
+    assert_eq!(bytes, size, "fill file has exactly the requested length");
+    assert!(
+        blocks * 512 >= size,
+        "fill must be backed by blocks ({} of {size} bytes)",
+        blocks * 512
+    );
+
+    let result = cli.join().expect("CLI thread panicked");
+    assert_eq!(
+        result.code, 0,
+        "expected exit 0, stderr:\n{}",
+        result.stderr
+    );
+    assert_eq!(
+        result.json().get("outcome").and_then(Value::as_str),
+        Some("COMPLETED"),
+        "CLI final record:\n{}",
+        result.stdout
+    );
+
+    assert!(
+        !topo.agent_path_exists(&fill),
+        "fill file must be removed after COMPLETED"
+    );
+    assert!(topo.journal_is_empty(), "journal empty after COMPLETED");
+}
+
+#[test]
+#[ignore = "requires rootless podman; run with -- --ignored"]
+fn disk_fill_halt_aborts_and_removes_the_fill() {
+    let topo = Topology::start("dfhalt");
+    // Long duration so the halt lands squarely mid-ACTIVE.
+    let yaml = disk_fill_yaml("df-halt-e2e", topo.agent_hostname(), 16, 30);
+    let yaml_path = write_yaml("dfhalt", &yaml);
+    let res = topo.cli(&["experiment", "run", "-f", &yaml_path.to_string_lossy()]);
+    assert_eq!(res.code, 0, "experiment rejected, stderr:\n{}", res.stderr);
+    let id = res
+        .json()
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("accepted experiment has an id")
+        .to_string();
+    wait_for_instance_state(&topo, &id, "ACTIVE");
+    let fill = fill_file(&id, topo.agent_hostname());
+    assert!(topo.agent_path_exists(&fill), "fill present while ACTIVE");
+
+    let halt = topo.cli(&["experiment", "halt", &id]);
+    assert_eq!(halt.code, 0, "halt rejected, stderr:\n{}", halt.stderr);
+
+    assert_eq!(wait_for_outcome(&topo, &id), "ABORTED");
+    assert!(!topo.agent_path_exists(&fill), "fill removed after halt");
+    assert!(topo.journal_is_empty(), "journal empty after halt");
+}
+
+#[test]
+#[ignore = "requires rootless podman; run with -- --ignored"]
+fn disk_fill_preflight_refusal_leaves_host_untouched() {
+    let topo = Topology::start("dfrefuse");
+    // Exbibyte-scale: no container filesystem satisfies size + headroom, so the
+    // runtime preflight refuses (exit 10 → ABORTED before inject).
+    let yaml = disk_fill_yaml("df-refuse-e2e", topo.agent_hostname(), 1 << 40, 5);
+    let yaml_path = write_yaml("dfrefuse", &yaml);
+    let run = topo.cli(&[
+        "experiment",
+        "run",
+        "-f",
+        &yaml_path.to_string_lossy(),
+        "--wait",
+    ]);
+    assert_eq!(
+        run.code, 4,
+        "a refused preflight must end the waited experiment ABORTED, stderr:\n{}",
+        run.stderr
+    );
+    assert_eq!(
+        run.json().get("outcome").and_then(Value::as_str),
+        Some("ABORTED"),
+        "CLI final record:\n{}",
+        run.stdout
+    );
+
+    let id = wait_for_experiment_id(&topo);
+    let fill = fill_file(&id, topo.agent_hostname());
+    assert!(
+        !topo.agent_path_exists(&fill),
+        "the fill file must never have been created"
+    );
+    assert!(
+        topo.journal_is_empty(),
+        "nothing was injected, journal empty"
+    );
+}
+
+#[test]
+#[ignore = "requires rootless podman; run with -- --ignored"]
+fn disk_fill_crash_replay_removes_the_fill() {
+    let topo = Topology::start("dfcrash");
+    let yaml = disk_fill_yaml("df-crash-e2e", topo.agent_hostname(), 16, 30);
+    let yaml_path = write_yaml("dfcrash", &yaml);
+    let res = topo.cli(&["experiment", "run", "-f", &yaml_path.to_string_lossy()]);
+    assert_eq!(res.code, 0, "experiment rejected, stderr:\n{}", res.stderr);
+    let id = res
+        .json()
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("accepted experiment has an id")
+        .to_string();
+    wait_for_instance_state(&topo, &id, "ACTIVE");
+    let fill = fill_file(&id, topo.agent_hostname());
+    assert!(topo.agent_path_exists(&fill), "fill present while ACTIVE");
+    assert!(!topo.journal_is_empty(), "journal has the live instance");
+
+    // A real crash: kill the process, restart the same container on the same
+    // data volume so restart replay (abort+cleanup) reverts the real fill.
+    topo.agent_kill();
+    topo.agent_restart();
+    topo.wait_for_registration();
+
+    assert_eq!(wait_for_outcome(&topo, &id), "ABORTED");
+    assert!(
+        !topo.agent_path_exists(&fill),
+        "replay removed the fill file"
+    );
+    assert!(topo.journal_is_empty(), "replay removed the journal entry");
 }

--- a/crates/plugins/disk-fill/Cargo.toml
+++ b/crates/plugins/disk-fill/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "disk-fill"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "disk-fill"
+path = "src/main.rs"
+
+[dependencies]
+faultforge-fault = { path = "../../fault" }
+serde_json = { workspace = true }
+humantime = { workspace = true }
+# tempfile_in: the un-leakable preflight writability probe (O_TMPFILE on Linux,
+# create+immediate-unlink elsewhere). Also serves the golden tests (tempdir).
+tempfile = { workspace = true }
+rustix = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/plugins/disk-fill/manifest.yaml
+++ b/crates/plugins/disk-fill/manifest.yaml
@@ -1,0 +1,20 @@
+# disk-fill: consume free space on a filesystem by allocating one file at
+# <fill_dir>/faultforge-<instance_id>.fill (fallocate; chunked-write fallback on
+# filesystems without fallocate — large fills there may hit the agent's
+# invocation timeout). Preflight refuses unless free space covers
+# size_mib + max(5% of capacity, 64 MiB): the fault can never fill a filesystem
+# to 100%, and the headroom is deliberately not a parameter. On CoW filesystems
+# (btrfs/ZFS) the free-space check is best effort. Filling a tmpfs consumes
+# memory, not disk; preflight warns but allows it.
+name: disk-fill
+version: "1"
+entrypoint: ./disk-fill
+params_schema:
+  fill_dir: string
+  size_mib: int
+requires:
+  binaries: []
+  privileges: []
+  preconditions:
+    - fill_dir_writable
+max_duration_secs: 3600

--- a/crates/plugins/disk-fill/src/main.rs
+++ b/crates/plugins/disk-fill/src/main.rs
@@ -1,0 +1,674 @@
+//! `disk-fill`: consume free space on a filesystem (the first host-mutating
+//! fault, issue #62).
+//!
+//! The fault's entire host effect is one file at the deterministic path
+//! `<fill_dir>/faultforge-<instance_id>.fill`, recomputable from
+//! `(instance_id, params)` alone so a cold-start revert needs no memory of the
+//! inject. Allocation prefers `fallocate(2)` (instant, no write IO) and falls
+//! back to chunked zero-writes where the filesystem lacks it. The plugin can
+//! never fill a filesystem to 100%: preflight demands
+//! `size + max(capacity/20, 64 MiB)` available. See `manifest.yaml` and the
+//! `disk-fill-plugin` spec.
+//!
+//! The binary is a thin imperative shell: `main` reads `SystemTime::now()`
+//! once and threads it into per-command logic; the space math and path
+//! derivation are pure functions unit-tested below.
+
+use std::fs::{File, OpenOptions};
+use std::io::{ErrorKind, Read, Write};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::SystemTime;
+
+use faultforge_fault::{
+    EXIT_CLEANUP_FAILED, EXIT_INJECT_FAILED, EXIT_PREFLIGHT_FAILED, EXIT_SUCCESS, InstanceId,
+    InstanceState, Level, Phase, PluginCommand, PluginEvent, PluginInput,
+};
+
+/// Generic unexpected-failure exit code (an "other non-zero" per the contract).
+/// Used for malformed stdin/argv and contract violations (params or an
+/// instance id that the agent's own validation should have refused).
+const EXIT_UNEXPECTED: u8 = 1;
+
+const MIB: u64 = 1024 * 1024;
+
+/// Headroom floor: even on a tiny filesystem at least this much stays free.
+const HEADROOM_FLOOR_BYTES: u64 = 64 * MIB;
+
+/// Headroom scale: 1/20th (5%) of filesystem capacity.
+const HEADROOM_CAPACITY_DIVISOR: u64 = 20;
+
+/// Chunk size for the no-`fallocate` fallback write loop.
+const WRITE_CHUNK_BYTES: usize = 8 * 1024 * 1024;
+
+/// `TMPFS_MAGIC` from `linux/magic.h`: filling tmpfs consumes memory, not disk,
+/// which preflight surfaces as a warning.
+#[cfg(target_os = "linux")]
+const TMPFS_MAGIC: i64 = 0x0102_1994;
+
+/// What a command decided: the NDJSON events to emit and the process exit code.
+struct Outcome {
+    events: Vec<PluginEvent>,
+    exit: u8,
+}
+
+fn main() -> ExitCode {
+    // Time as data: read the wall clock once, thread it into pure logic.
+    let now = SystemTime::now();
+
+    let Some(word) = std::env::args().nth(1) else {
+        eprintln!("usage: disk-fill <preflight|inject|report|abort|cleanup>");
+        return ExitCode::from(EXIT_UNEXPECTED);
+    };
+    let command = match PluginCommand::parse(&word) {
+        Ok(command) => command,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::from(EXIT_UNEXPECTED);
+        }
+    };
+
+    let input = match read_input() {
+        Ok(input) => input,
+        Err(err) => {
+            eprintln!("failed to read plugin input: {err}");
+            return ExitCode::from(EXIT_UNEXPECTED);
+        }
+    };
+
+    let outcome = run(command, &input, now);
+    emit_all(&outcome.events);
+    ExitCode::from(outcome.exit)
+}
+
+/// Read and parse the single stdin JSON [`PluginInput`].
+fn read_input() -> Result<PluginInput, String> {
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| e.to_string())?;
+    serde_json::from_str(&buf).map_err(|e| e.to_string())
+}
+
+/// Write every event to stdout as one NDJSON line, in order.
+fn emit_all(events: &[PluginEvent]) {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    for event in events {
+        // Serializing these types cannot fail; if a line somehow can't be written
+        // (e.g. a closed pipe), there is nothing useful the plugin can do.
+        if let Ok(line) = serde_json::to_string(event) {
+            let _ = writeln!(lock, "{line}");
+        }
+    }
+}
+
+/// Dispatch a command over its validated input and the captured time.
+fn run(command: PluginCommand, input: &PluginInput, now: SystemTime) -> Outcome {
+    // In production the agent validates params against the schema first; a
+    // missing/mistyped param here is a contract violation, not a precondition
+    // failure.
+    let Some(fill_dir) = input.params.get("fill_dir").and_then(|v| v.as_str()) else {
+        return fail(
+            input,
+            now,
+            EXIT_UNEXPECTED,
+            "params.fill_dir missing or not a string".to_string(),
+        );
+    };
+    let Some(size_mib) = input
+        .params
+        .get("size_mib")
+        .and_then(serde_json::Value::as_i64)
+    else {
+        return fail(
+            input,
+            now,
+            EXIT_UNEXPECTED,
+            "params.size_mib missing or not an integer".to_string(),
+        );
+    };
+    let fill_dir = Path::new(fill_dir);
+
+    // Defense in depth: a relative fill_dir is a precondition failure (exit 10)
+    // in preflight; any other command receiving one means the agent skipped
+    // preflight — a contract violation — so refuse rather than resolve it
+    // against the process cwd.
+    if !fill_dir.is_absolute() {
+        let exit = if command == PluginCommand::Preflight {
+            EXIT_PREFLIGHT_FAILED
+        } else {
+            EXIT_UNEXPECTED
+        };
+        return fail(
+            input,
+            now,
+            exit,
+            format!("fill_dir is not absolute: {}", fill_dir.display()),
+        );
+    }
+
+    // The agent's boundary validation confines instance ids to a filename-safe
+    // charset; an id that composes to anything but a direct child of fill_dir
+    // is a contract violation for every command, preflight included.
+    let fill_path = match fill_file_path(fill_dir, &input.instance_id) {
+        Ok(path) => path,
+        Err(msg) => return fail(input, now, EXIT_UNEXPECTED, msg),
+    };
+
+    match command {
+        PluginCommand::Preflight => preflight(input, now, fill_dir, &fill_path, size_mib),
+        PluginCommand::Inject => inject(input, now, &fill_path, size_mib),
+        PluginCommand::Report => report(input, now, &fill_path),
+        PluginCommand::Abort => revert(input, now, &fill_path, RevertKind::Abort),
+        PluginCommand::Cleanup => revert(input, now, &fill_path, RevertKind::Cleanup),
+    }
+}
+
+// ===== commands =====
+
+/// Static param checks in both phases; host probes (directory, writability,
+/// headroom, tmpfs warning) only in `runtime`. Apart from the transient
+/// anonymous probe, preflight never mutates the host.
+fn preflight(
+    input: &PluginInput,
+    now: SystemTime,
+    fill_dir: &Path,
+    fill_path: &Path,
+    size_mib: i64,
+) -> Outcome {
+    let size = match size_bytes(size_mib) {
+        Ok(size) => size,
+        Err(msg) => return fail(input, now, EXIT_PREFLIGHT_FAILED, msg),
+    };
+
+    let mut events = Vec::new();
+    if input.phase == Phase::Runtime {
+        match std::fs::metadata(fill_dir) {
+            Ok(meta) if meta.is_dir() => {}
+            Ok(_) => {
+                return fail(
+                    input,
+                    now,
+                    EXIT_PREFLIGHT_FAILED,
+                    format!("fill_dir is not a directory: {}", fill_dir.display()),
+                );
+            }
+            Err(e) => {
+                return fail(
+                    input,
+                    now,
+                    EXIT_PREFLIGHT_FAILED,
+                    format!("fill_dir {} is not usable: {e}", fill_dir.display()),
+                );
+            }
+        }
+        if fill_path.exists() {
+            return fail(
+                input,
+                now,
+                EXIT_PREFLIGHT_FAILED,
+                format!(
+                    "fill file already exists: {} — was this instance already injected?",
+                    fill_path.display()
+                ),
+            );
+        }
+        if let Err(msg) = probe_writable(fill_dir) {
+            return fail(input, now, EXIT_PREFLIGHT_FAILED, msg);
+        }
+        if let Err(msg) = check_headroom(fill_dir, size) {
+            return fail(input, now, EXIT_PREFLIGHT_FAILED, msg);
+        }
+        if is_tmpfs(fill_dir) {
+            events.push(log(
+                input,
+                now,
+                Level::Warn,
+                format!(
+                    "{} is tmpfs: this fill consumes memory, not disk",
+                    fill_dir.display()
+                ),
+            ));
+        }
+    }
+
+    events.push(status(input, now, InstanceState::Preflight));
+    Outcome {
+        events,
+        exit: EXIT_SUCCESS,
+    }
+}
+
+/// Create the fill file exclusively, allocate it, verify the allocation is
+/// backed by real blocks, then exit; the fault's active state is purely the
+/// file's existence. Any failure after the create removes the partial file so
+/// exit 20 always means the host is unaffected.
+fn inject(input: &PluginInput, now: SystemTime, fill_path: &Path, size_mib: i64) -> Outcome {
+    let size = match size_bytes(size_mib) {
+        Ok(size) => size,
+        // Preflight already vetted the size; reaching inject with a bad one is
+        // a contract violation, and nothing has touched the host yet.
+        Err(msg) => return fail(input, now, EXIT_UNEXPECTED, msg),
+    };
+
+    let mut events = vec![status(input, now, InstanceState::Injecting)];
+
+    let file = match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(fill_path)
+    {
+        Ok(file) => file,
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+            // Not ours to clobber: inject runs at most once per instance, so a
+            // file already at this path is an anomaly worth preserving.
+            events.push(log(
+                input,
+                now,
+                Level::Error,
+                format!(
+                    "fill file already exists, refusing to claim it: {}",
+                    fill_path.display()
+                ),
+            ));
+            return Outcome {
+                events,
+                exit: EXIT_INJECT_FAILED,
+            };
+        }
+        Err(e) => {
+            events.push(log(
+                input,
+                now,
+                Level::Error,
+                format!("cannot create fill file {}: {e}", fill_path.display()),
+            ));
+            return Outcome {
+                events,
+                exit: EXIT_INJECT_FAILED,
+            };
+        }
+    };
+
+    let mechanism = match allocate(&file, size) {
+        Ok(mechanism) => mechanism,
+        Err(e) => {
+            return abandon_inject(
+                input,
+                now,
+                events,
+                fill_path,
+                format!("allocation failed: {e}"),
+            );
+        }
+    };
+
+    // Trust nothing: some filesystems report fallocate success without
+    // reserving blocks, and a sparse fill would be a silent no-op fault.
+    match file.metadata() {
+        Ok(meta) if allocation_backed(meta.len(), meta.blocks(), size) => {}
+        Ok(meta) => {
+            return abandon_inject(
+                input,
+                now,
+                events,
+                fill_path,
+                format!(
+                    "allocation is not backed by blocks ({} of {size} bytes) — refusing a silent no-op fault",
+                    meta.blocks().saturating_mul(512)
+                ),
+            );
+        }
+        Err(e) => {
+            return abandon_inject(
+                input,
+                now,
+                events,
+                fill_path,
+                format!("cannot verify allocation: {e}"),
+            );
+        }
+    }
+
+    if mechanism == Mechanism::WriteLoop {
+        events.push(log(
+            input,
+            now,
+            Level::Warn,
+            "fallocate unavailable on this filesystem; filled by chunked writes",
+        ));
+    }
+    events.push(status(input, now, InstanceState::Active));
+    Outcome {
+        events,
+        exit: EXIT_SUCCESS,
+    }
+}
+
+/// Read-only reconciliation probe: ownership is the id-derived filename, so
+/// existence alone answers it; content is never inspected.
+fn report(input: &PluginInput, now: SystemTime, fill_path: &Path) -> Outcome {
+    match std::fs::metadata(fill_path) {
+        Ok(_) => Outcome {
+            events: vec![status(input, now, InstanceState::Active)],
+            exit: EXIT_SUCCESS,
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => Outcome {
+            events: vec![status(input, now, InstanceState::Done)],
+            exit: EXIT_SUCCESS,
+        },
+        Err(e) => fail(
+            input,
+            now,
+            EXIT_UNEXPECTED,
+            format!("cannot stat fill file: {e}"),
+        ),
+    }
+}
+
+/// Which revert path is running; they share the removal but differ in the
+/// telemetry the spec pins (`abort` announces `RECOVERING` first).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RevertKind {
+    Abort,
+    Cleanup,
+}
+
+/// Remove the fill file; idempotent (already-absent is success). Retry
+/// ownership on real failures belongs to the agent runtime, not here.
+fn revert(input: &PluginInput, now: SystemTime, fill_path: &Path, kind: RevertKind) -> Outcome {
+    let mut events = Vec::new();
+    if kind == RevertKind::Abort {
+        events.push(status(input, now, InstanceState::Recovering));
+    }
+    match std::fs::remove_file(fill_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => {
+            events.push(log(
+                input,
+                now,
+                Level::Error,
+                format!("failed to remove fill file: {e}"),
+            ));
+            return Outcome {
+                events,
+                exit: EXIT_CLEANUP_FAILED,
+            };
+        }
+    }
+    events.push(status(input, now, InstanceState::Done));
+    Outcome {
+        events,
+        exit: EXIT_SUCCESS,
+    }
+}
+
+// ===== allocation =====
+
+/// How the fill file's space was obtained.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mechanism {
+    // Only the Linux `allocate` constructs this; the dev-platform build still
+    // needs the variant so the match sites stay platform-independent.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    Fallocate,
+    WriteLoop,
+}
+
+/// Allocate `size` bytes in `file`: `fallocate(2)` where the platform and
+/// filesystem support it, otherwise the chunked write loop. The final
+/// `sync_all` in the write path also forces delayed allocation to materialise
+/// so the caller's `st_blocks` verification measures reality.
+#[cfg(target_os = "linux")]
+fn allocate(file: &File, size: u64) -> std::io::Result<Mechanism> {
+    use rustix::io::Errno;
+    match rustix::fs::fallocate(file, rustix::fs::FallocateFlags::empty(), 0, size) {
+        Ok(()) => {
+            file.sync_all()?;
+            Ok(Mechanism::Fallocate)
+        }
+        Err(Errno::OPNOTSUPP | Errno::INVAL | Errno::NOSYS) => {
+            write_zeroes(file, size)?;
+            Ok(Mechanism::WriteLoop)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Non-Linux fallback (the dev platform): no `fallocate(2)`, always the write
+/// loop. Production agents target Linux.
+#[cfg(not(target_os = "linux"))]
+fn allocate(file: &File, size: u64) -> std::io::Result<Mechanism> {
+    write_zeroes(file, size)?;
+    Ok(Mechanism::WriteLoop)
+}
+
+/// Append zeroed chunks until `size` bytes are written, then fsync.
+fn write_zeroes(mut file: &File, size: u64) -> std::io::Result<()> {
+    let chunk = vec![0_u8; WRITE_CHUNK_BYTES];
+    let mut remaining = size;
+    while remaining > 0 {
+        let len = usize::try_from(remaining.min(chunk.len() as u64))
+            .map_err(|_| std::io::Error::other("chunk length exceeds usize"))?;
+        file.write_all(&chunk[..len])?;
+        remaining -= len as u64;
+    }
+    file.sync_all()
+}
+
+/// Push a failure log, remove the partial fill file, and exit 20. Removal keeps
+/// the machine's "inject failed; host unaffected" reason truthful; a removal
+/// failure at this point (vanishingly unlikely right after a successful create)
+/// is logged so the operator knows the host needs a manual look.
+fn abandon_inject(
+    input: &PluginInput,
+    now: SystemTime,
+    mut events: Vec<PluginEvent>,
+    fill_path: &Path,
+    msg: String,
+) -> Outcome {
+    events.push(log(input, now, Level::Error, msg));
+    match std::fs::remove_file(fill_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => {
+            events.push(log(
+                input,
+                now,
+                Level::Error,
+                format!(
+                    "could not remove partial fill file {}: {e}",
+                    fill_path.display()
+                ),
+            ));
+        }
+    }
+    Outcome {
+        events,
+        exit: EXIT_INJECT_FAILED,
+    }
+}
+
+// ===== host probes =====
+
+/// Honest writability check: an actual write, not permission bits (which lie
+/// under ACLs). `tempfile_in` is un-leakable by construction — `O_TMPFILE`
+/// (anonymous) on Linux, create+immediate-unlink elsewhere — so a crashed
+/// preflight leaves nothing named behind.
+fn probe_writable(fill_dir: &Path) -> Result<(), String> {
+    let mut probe = tempfile::tempfile_in(fill_dir)
+        .map_err(|e| format!("fill_dir {} is not writable: {e}", fill_dir.display()))?;
+    probe
+        .write_all(b"faultforge disk-fill probe")
+        .map_err(|e| format!("fill_dir {} is not writable: {e}", fill_dir.display()))
+}
+
+/// The headroom guarantee: refuse unless `available >= size + headroom`.
+/// Measured with `f_bavail` (blocks available to unprivileged users), the
+/// conservative bound whether or not the plugin runs as root.
+fn check_headroom(fill_dir: &Path, size: u64) -> Result<(), String> {
+    let vfs = rustix::fs::statvfs(fill_dir)
+        .map_err(|e| format!("cannot statvfs {}: {e}", fill_dir.display()))?;
+    let available = vfs.f_bavail.saturating_mul(vfs.f_frsize);
+    let capacity = vfs.f_blocks.saturating_mul(vfs.f_frsize);
+    if headroom_allows(size, available, capacity) {
+        Ok(())
+    } else {
+        Err(format!(
+            "refusing to fill: {size} bytes requested but only {available} available and \
+             {headroom} headroom must stay free (capacity {capacity})",
+            headroom = required_headroom(capacity)
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn is_tmpfs(fill_dir: &Path) -> bool {
+    rustix::fs::statfs(fill_dir).is_ok_and(|fs| fs.f_type == TMPFS_MAGIC)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_tmpfs(_fill_dir: &Path) -> bool {
+    false
+}
+
+// ===== pure core =====
+
+/// The deterministic fill-file path, verified to be a direct child of
+/// `fill_dir` (defense in depth on top of the agent's id-charset guarantee).
+fn fill_file_path(fill_dir: &Path, instance_id: &InstanceId) -> Result<PathBuf, String> {
+    let name = format!("faultforge-{instance_id}.fill");
+    let path = fill_dir.join(&name);
+    let contained = path.parent() == Some(fill_dir)
+        && path.file_name().and_then(|f| f.to_str()) == Some(name.as_str());
+    if contained {
+        Ok(path)
+    } else {
+        Err(format!(
+            "instance id composes a fill path outside fill_dir: {instance_id}"
+        ))
+    }
+}
+
+/// The requested size in bytes; `size_mib` must be >= 1 and must not overflow.
+fn size_bytes(size_mib: i64) -> Result<u64, String> {
+    let mib = u64::try_from(size_mib).ok().filter(|&m| m >= 1);
+    mib.and_then(|m| m.checked_mul(MIB))
+        .ok_or_else(|| format!("size_mib must be >= 1 and addressable in bytes, got {size_mib}"))
+}
+
+/// The space that must stay free after the fill: 5% of capacity, floored at
+/// [`HEADROOM_FLOOR_BYTES`]. Deliberately not operator-configurable.
+fn required_headroom(capacity: u64) -> u64 {
+    (capacity / HEADROOM_CAPACITY_DIVISOR).max(HEADROOM_FLOOR_BYTES)
+}
+
+/// True if `available` covers the fill plus the headroom that must survive it.
+fn headroom_allows(size: u64, available: u64, capacity: u64) -> bool {
+    size.checked_add(required_headroom(capacity))
+        .is_some_and(|need| available >= need)
+}
+
+/// True if the allocation is real: the file has exactly the requested length
+/// and its block usage covers it (a sparse file passes the length test but
+/// consumes nothing).
+fn allocation_backed(len: u64, blocks_512: u64, size: u64) -> bool {
+    len == size && blocks_512.saturating_mul(512) >= size
+}
+
+// ===== event helpers =====
+
+/// Build a single-`log`-event failure outcome with the given exit code.
+fn fail(input: &PluginInput, now: SystemTime, exit: u8, msg: String) -> Outcome {
+    Outcome {
+        events: vec![log(input, now, Level::Error, msg)],
+        exit,
+    }
+}
+
+/// Build a `status` event for this instance at `now`.
+fn status(input: &PluginInput, now: SystemTime, state: InstanceState) -> PluginEvent {
+    PluginEvent::status(ts(now), input.instance_id.clone(), state)
+}
+
+/// Build a `log` event for this instance at `now`.
+fn log(input: &PluginInput, now: SystemTime, level: Level, msg: impl Into<String>) -> PluginEvent {
+    PluginEvent::log(ts(now), input.instance_id.clone(), level, msg)
+}
+
+/// Format `now` as an RFC3339 UTC timestamp with second precision (`…Z`).
+fn ts(now: SystemTime) -> String {
+    humantime::format_rfc3339_seconds(now).to_string()
+}
+
+// ===== pure-core tests =====
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headroom_is_five_percent_with_a_floor() {
+        // 10 TiB capacity: 5% = 512 GiB wins over the floor.
+        let ten_tib = 10 * 1024 * 1024 * MIB;
+        assert_eq!(required_headroom(ten_tib), ten_tib / 20);
+        // 1 GiB capacity: 5% = ~51 MiB, the 64 MiB floor wins.
+        assert_eq!(required_headroom(1024 * MIB), HEADROOM_FLOOR_BYTES);
+        assert_eq!(required_headroom(0), HEADROOM_FLOOR_BYTES);
+    }
+
+    #[test]
+    fn headroom_boundary_is_exact() {
+        let capacity = 100 * 1024 * MIB; // 100 GiB → headroom = 5 GiB
+        let headroom = required_headroom(capacity);
+        let size = 10 * 1024 * MIB;
+        assert!(headroom_allows(size, size + headroom, capacity));
+        assert!(!headroom_allows(size, size + headroom - 1, capacity));
+    }
+
+    #[test]
+    fn headroom_overflow_refuses() {
+        assert!(!headroom_allows(u64::MAX, u64::MAX, u64::MAX));
+    }
+
+    #[test]
+    fn size_bytes_bounds() {
+        assert_eq!(size_bytes(1).unwrap(), MIB);
+        assert!(size_bytes(0).is_err());
+        assert!(size_bytes(-5).is_err());
+        assert!(size_bytes(i64::MAX).is_err(), "byte size must not overflow");
+    }
+
+    #[test]
+    fn allocation_backed_rejects_sparse_and_truncated() {
+        let size = 8 * MIB;
+        assert!(allocation_backed(size, size / 512, size));
+        assert!(!allocation_backed(size, 0, size), "sparse file");
+        assert!(!allocation_backed(size - 1, size / 512, size), "short file");
+        // Filesystems may round block usage up, never down past the data.
+        assert!(allocation_backed(size, size / 512 + 8, size));
+    }
+
+    #[test]
+    fn fill_path_is_a_direct_child_with_the_id_embedded() {
+        let dir = Path::new("/var/lib/faultforge");
+        let path = fill_file_path(dir, &InstanceId::from("exp1:web01:0")).unwrap();
+        assert_eq!(
+            path,
+            Path::new("/var/lib/faultforge/faultforge-exp1:web01:0.fill")
+        );
+    }
+
+    #[test]
+    fn traversal_hostile_id_is_refused() {
+        let dir = Path::new("/var/lib/faultforge");
+        // The agent's boundary validation refuses such ids; this is the
+        // defense-in-depth layer behind it.
+        assert!(fill_file_path(dir, &InstanceId::from("../../etc/cron.d/x")).is_err());
+        assert!(fill_file_path(dir, &InstanceId::from("a/b")).is_err());
+    }
+}

--- a/crates/plugins/disk-fill/tests/golden.rs
+++ b/crates/plugins/disk-fill/tests/golden.rs
@@ -1,0 +1,447 @@
+//! Golden tests: drive the built `disk-fill` binary end to end — stdin JSON in,
+//! NDJSON + exit code + filesystem effects out.
+//!
+//! Permission-based cases (`exit 10`/`30`) are skipped under root, which
+//! ignores the permission bits they rely on. Forced mid-allocation failure
+//! (ENOSPC) needs a size-capped filesystem and is exercised only by the pure
+//! `allocation_backed`/`abandon_inject` unit coverage plus the e2e suite.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::Write;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use faultforge_fault::{EventBody, InstanceState, Level, Phase, PluginEvent, PluginInput};
+
+const MIB: u64 = 1024 * 1024;
+
+/// The instance id used across the tests — deliberately the production shape
+/// `<experiment>:<hostname>:<index>`, so the `:` filename case is always on.
+const INSTANCE_ID: &str = "exp1:web01:0";
+
+/// The deterministic fill-file path the plugin derives for [`INSTANCE_ID`].
+fn fill_path(dir: &Path) -> std::path::PathBuf {
+    dir.join(format!("faultforge-{INSTANCE_ID}.fill"))
+}
+
+/// The result of one plugin invocation.
+struct Run {
+    events: Vec<PluginEvent>,
+    exit: Option<i32>,
+}
+
+/// Spawn the built binary for `command`, feed `input_json` on stdin, and collect
+/// the parsed NDJSON events and exit code. Every stdout line must parse as a
+/// [`PluginEvent`] (the contract-shape gate).
+fn run(command: &str, input_json: &str) -> Run {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_disk-fill"))
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn disk-fill");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(input_json.as_bytes())
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait for disk-fill");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+    let events = stdout
+        .lines()
+        .map(|line| {
+            serde_json::from_str::<PluginEvent>(line)
+                .unwrap_or_else(|e| panic!("stdout line is not a PluginEvent: {line:?}: {e}"))
+        })
+        .collect();
+    Run {
+        events,
+        exit: output.status.code(),
+    }
+}
+
+/// Build a stdin `PluginInput` JSON string by serializing the shared contract
+/// type, so the tests exercise the exact wire shape.
+fn input_for(instance_id: &str, fill_dir: &str, size_mib: i64, phase: Phase) -> String {
+    let params = serde_json::json!({ "fill_dir": fill_dir, "size_mib": size_mib })
+        .as_object()
+        .unwrap()
+        .clone();
+    let input = PluginInput {
+        instance_id: instance_id.into(),
+        params,
+        deadline_unix: 1_700_000_600,
+        phase,
+    };
+    serde_json::to_string(&input).unwrap()
+}
+
+fn input(fill_dir: &str, size_mib: i64, phase: Phase) -> String {
+    input_for(INSTANCE_ID, fill_dir, size_mib, phase)
+}
+
+/// The status states from a run, in emission order (log lines dropped).
+fn states(run: &Run) -> Vec<InstanceState> {
+    run.events
+        .iter()
+        .filter_map(|e| match e.body {
+            EventBody::Status { state } => Some(state),
+            EventBody::Log { .. } => None,
+        })
+        .collect()
+}
+
+/// True if the run emitted a `log` event at `level`.
+fn has_log(run: &Run, level: Level) -> bool {
+    run.events
+        .iter()
+        .any(|e| matches!(e.body, EventBody::Log { level: l, .. } if l == level))
+}
+
+/// True if the current process is uid 0. Permission-based cases are meaningless
+/// under root, which bypasses the bits.
+fn running_as_root() -> bool {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .is_some_and(|s| s.trim() == "0")
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).expect("chmod");
+}
+
+// ===== preflight =====
+
+#[test]
+fn preflight_succeeds_in_both_phases_and_leaves_no_trace() {
+    for phase in [Phase::Install, Phase::Runtime] {
+        let dir = tempfile::tempdir().unwrap();
+        let r = run("preflight", &input(dir.path().to_str().unwrap(), 1, phase));
+        assert_eq!(r.exit, Some(0), "phase {phase:?}");
+        assert_eq!(
+            states(&r),
+            vec![InstanceState::Preflight],
+            "phase {phase:?}"
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            0,
+            "preflight must leave nothing behind ({phase:?})"
+        );
+    }
+}
+
+#[test]
+fn preflight_install_phase_is_static_only() {
+    // A fill_dir that does not exist: runtime refuses, install does not care.
+    let r = run(
+        "preflight",
+        &input("/nonexistent/faultforge-e2e", 1, Phase::Install),
+    );
+    assert_eq!(r.exit, Some(0));
+    assert_eq!(states(&r), vec![InstanceState::Preflight]);
+}
+
+#[test]
+fn preflight_missing_dir_is_runtime_precondition_failure() {
+    let r = run(
+        "preflight",
+        &input("/nonexistent/faultforge-e2e", 1, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(10));
+    assert!(states(&r).is_empty());
+    assert!(has_log(&r, Level::Error));
+}
+
+#[test]
+fn preflight_relative_dir_is_precondition_failure() {
+    for phase in [Phase::Install, Phase::Runtime] {
+        let r = run("preflight", &input("relative/dir", 1, phase));
+        assert_eq!(r.exit, Some(10), "phase {phase:?}");
+        assert!(states(&r).is_empty());
+    }
+}
+
+#[test]
+fn preflight_nonpositive_size_is_precondition_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    for size in [0, -3] {
+        let r = run(
+            "preflight",
+            &input(dir.path().to_str().unwrap(), size, Phase::Install),
+        );
+        assert_eq!(r.exit, Some(10), "size {size}");
+    }
+}
+
+#[test]
+fn preflight_overflowing_size_is_precondition_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let r = run(
+        "preflight",
+        &input(dir.path().to_str().unwrap(), i64::MAX, Phase::Install),
+    );
+    assert_eq!(r.exit, Some(10));
+}
+
+#[test]
+fn preflight_headroom_breach_is_refused() {
+    // Petabytes: no test machine satisfies size + headroom, and the message
+    // must name the shortfall rather than fail on arithmetic.
+    let dir = tempfile::tempdir().unwrap();
+    let r = run(
+        "preflight",
+        &input(dir.path().to_str().unwrap(), 1 << 40, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(10));
+    assert!(has_log(&r, Level::Error));
+}
+
+#[test]
+#[cfg(unix)]
+fn preflight_unwritable_dir_is_runtime_precondition_failure() {
+    if running_as_root() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let sub = dir.path().join("locked");
+    std::fs::create_dir(&sub).unwrap();
+    set_mode(&sub, 0o555);
+    let r = run(
+        "preflight",
+        &input(sub.to_str().unwrap(), 1, Phase::Runtime),
+    );
+    set_mode(&sub, 0o755); // restore so the tempdir can be cleaned up
+    assert_eq!(r.exit, Some(10));
+}
+
+#[test]
+fn preflight_preexisting_fill_file_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(fill_path(dir.path()), b"leftover").unwrap();
+    let r = run(
+        "preflight",
+        &input(dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(10));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn preflight_on_tmpfs_warns_but_allows() {
+    let shm = Path::new("/dev/shm");
+    if !shm.is_dir() {
+        eprintln!("skipping: /dev/shm not present");
+        return;
+    }
+    let dir = tempfile::tempdir_in(shm).unwrap();
+    let r = run(
+        "preflight",
+        &input(dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(0), "tmpfs is allowed");
+    assert!(
+        has_log(&r, Level::Warn),
+        "tmpfs must be flagged: fill consumes memory, not disk"
+    );
+    assert_eq!(states(&r), vec![InstanceState::Preflight]);
+}
+
+// ===== inject =====
+
+#[test]
+fn inject_allocates_the_exact_size_backed_by_blocks() {
+    let dir = tempfile::tempdir().unwrap();
+    let size_mib = 8_i64;
+    let r = run(
+        "inject",
+        &input(dir.path().to_str().unwrap(), size_mib, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(0));
+    assert_eq!(
+        states(&r),
+        vec![InstanceState::Injecting, InstanceState::Active],
+        "INJECTING must precede ACTIVE"
+    );
+
+    let meta = std::fs::metadata(fill_path(dir.path())).expect("fill file exists");
+    let size = 8 * MIB;
+    assert_eq!(meta.len(), size, "exact requested length");
+    assert!(
+        meta.blocks() * 512 >= size,
+        "allocation must be backed by blocks, got {} of {size}",
+        meta.blocks() * 512
+    );
+}
+
+#[test]
+fn inject_preexisting_file_is_refused_and_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = fill_path(dir.path());
+    let foreign = b"not ours to clobber";
+    std::fs::write(&path, foreign).unwrap();
+
+    let r = run(
+        "inject",
+        &input(dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(20));
+    assert!(!states(&r).contains(&InstanceState::Active));
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        foreign,
+        "a pre-existing file must survive a refused inject byte-identical"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn inject_into_unwritable_dir_fails_with_no_file() {
+    if running_as_root() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let sub = dir.path().join("locked");
+    std::fs::create_dir(&sub).unwrap();
+    set_mode(&sub, 0o555);
+    let r = run("inject", &input(sub.to_str().unwrap(), 1, Phase::Runtime));
+    set_mode(&sub, 0o755); // restore before asserting
+
+    assert_eq!(r.exit, Some(20));
+    assert!(!fill_path(&sub).exists(), "no fill file may remain");
+    assert!(has_log(&r, Level::Error));
+}
+
+#[test]
+fn inject_with_traversal_hostile_id_is_rejected() {
+    // The agent's boundary validation refuses such ids; this pins the
+    // defense-in-depth layer behind it.
+    let dir = tempfile::tempdir().unwrap();
+    let r = run(
+        "inject",
+        &input_for("../evil", dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert_ne!(r.exit, Some(0));
+    assert!(!states(&r).contains(&InstanceState::Active));
+    assert_eq!(
+        std::fs::read_dir(dir.path()).unwrap().count(),
+        0,
+        "nothing may be created for a hostile id"
+    );
+}
+
+// ===== report =====
+
+#[test]
+fn report_present_fill_file_is_active_and_read_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_json = input(dir.path().to_str().unwrap(), 1, Phase::Runtime);
+    run("inject", &in_json);
+    let before = std::fs::metadata(fill_path(dir.path())).unwrap();
+
+    let r = run("report", &in_json);
+    assert_eq!(r.exit, Some(0));
+    assert_eq!(states(&r), vec![InstanceState::Active]);
+
+    let after = std::fs::metadata(fill_path(dir.path())).unwrap();
+    assert_eq!(before.len(), after.len(), "report must not modify the file");
+}
+
+#[test]
+fn report_absent_fill_file_is_done() {
+    let dir = tempfile::tempdir().unwrap();
+    let r = run(
+        "report",
+        &input(dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert_eq!(r.exit, Some(0));
+    assert_eq!(states(&r), vec![InstanceState::Done]);
+}
+
+// ===== abort / cleanup =====
+
+#[test]
+fn abort_removes_the_fill_file_via_recovering_done() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_json = input(dir.path().to_str().unwrap(), 1, Phase::Runtime);
+    run("inject", &in_json);
+    assert!(fill_path(dir.path()).exists(), "setup: inject must fill");
+
+    let r = run("abort", &in_json);
+    assert_eq!(r.exit, Some(0));
+    assert_eq!(
+        states(&r),
+        vec![InstanceState::Recovering, InstanceState::Done]
+    );
+    assert!(
+        !fill_path(dir.path()).exists(),
+        "abort must remove the file"
+    );
+}
+
+#[test]
+fn cleanup_twice_is_success_twice() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_json = input(dir.path().to_str().unwrap(), 1, Phase::Runtime);
+    run("inject", &in_json);
+    assert!(fill_path(dir.path()).exists(), "setup: inject must fill");
+
+    let first = run("cleanup", &in_json);
+    assert_eq!(first.exit, Some(0));
+    assert_eq!(states(&first), vec![InstanceState::Done]);
+    assert!(!fill_path(dir.path()).exists());
+
+    let second = run("cleanup", &in_json);
+    assert_eq!(second.exit, Some(0), "cleanup is idempotent");
+    assert_eq!(states(&second), vec![InstanceState::Done]);
+}
+
+#[test]
+#[cfg(unix)]
+fn cleanup_with_unremovable_fill_file_exits_30() {
+    if running_as_root() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let sub = dir.path().join("locked");
+    std::fs::create_dir(&sub).unwrap();
+    let in_json = input(sub.to_str().unwrap(), 1, Phase::Runtime);
+    run("inject", &in_json);
+    assert!(fill_path(&sub).exists(), "setup: fill must exist");
+
+    set_mode(&sub, 0o555); // forbid removal from the directory
+    let r = run("cleanup", &in_json);
+    set_mode(&sub, 0o755); // restore before asserting / cleanup
+
+    assert_eq!(r.exit, Some(30));
+    assert!(has_log(&r, Level::Error));
+}
+
+// ===== contract shape =====
+
+#[test]
+fn every_emitted_line_carries_ts_and_instance_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let r = run(
+        "inject",
+        &input(dir.path().to_str().unwrap(), 1, Phase::Runtime),
+    );
+    assert!(!r.events.is_empty());
+    for event in &r.events {
+        assert_eq!(event.instance_id.as_str(), INSTANCE_ID);
+        assert!(
+            event.ts.ends_with('Z'),
+            "ts must be RFC3339 UTC: {}",
+            event.ts
+        );
+    }
+}

--- a/crates/plugins/disk-fill/tests/manifest.rs
+++ b/crates/plugins/disk-fill/tests/manifest.rs
@@ -1,0 +1,91 @@
+//! The shipped `manifest.yaml` loads via `faultforge-fault` and matches the
+//! declared contract (identity, entrypoint, params schema, precondition,
+//! duration limit).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use faultforge_fault::{Manifest, ParamType};
+
+#[test]
+fn shipped_manifest_conforms_to_contract() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("manifest.yaml");
+    let yaml =
+        std::fs::read_to_string(&path).expect("manifest.yaml must be present alongside the crate");
+    let manifest = Manifest::parse(&yaml).expect("shipped manifest must parse and validate");
+
+    assert_eq!(manifest.name.as_str(), "disk-fill");
+    assert_eq!(manifest.version, "1");
+    assert_eq!(manifest.identity(), "disk-fill@1");
+    assert_eq!(manifest.entrypoint, "./disk-fill");
+
+    assert_eq!(manifest.params_schema.len(), 2);
+    assert_eq!(
+        manifest.params_schema.get("fill_dir"),
+        Some(&ParamType::String)
+    );
+    assert_eq!(
+        manifest.params_schema.get("size_mib"),
+        Some(&ParamType::Int)
+    );
+
+    assert!(manifest.requires.binaries.is_empty());
+    assert!(manifest.requires.privileges.is_empty());
+    assert_eq!(manifest.requires.preconditions, vec!["fill_dir_writable"]);
+
+    assert_eq!(manifest.max_duration_secs, 3600);
+}
+
+/// Compute `cat <manifest> <binary> | sha256` with coreutils, trying `sha256sum`
+/// (Linux) then `shasum -a 256` (macOS). Returns `None` if neither tool exists.
+#[cfg(unix)]
+fn coreutils_sha256(manifest: &Path, binary: &Path) -> Option<String> {
+    for tool in ["sha256sum", "shasum -a 256"] {
+        let cmd = format!(
+            "cat '{}' '{}' | {tool}",
+            manifest.display(),
+            binary.display()
+        );
+        let output = Command::new("sh").arg("-c").arg(&cmd).output().ok()?;
+        if output.status.success() {
+            let stdout = String::from_utf8(output.stdout).ok()?;
+            if let Some(hex) = stdout.split_whitespace().next()
+                && hex.len() == 64
+            {
+                return Some(hex.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The digest `faultforge-fault` computes over the *real* shipped manifest and
+/// built binary equals what an operator gets from `cat manifest.yaml disk-fill
+/// | sha256sum` (spec: "Digest is reproducible with coreutils").
+#[test]
+#[cfg(unix)]
+fn shipped_plugin_digest_reproduces_with_coreutils() {
+    let manifest_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("manifest.yaml");
+    let binary_src = Path::new(env!("CARGO_BIN_EXE_disk-fill"));
+
+    // Assemble a catalog entry (manifest + entrypoint co-located) in a tempdir.
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_dst = dir.path().join("manifest.yaml");
+    let binary_dst = dir.path().join("disk-fill");
+    std::fs::copy(&manifest_src, &manifest_dst).unwrap();
+    std::fs::copy(binary_src, &binary_dst).unwrap();
+
+    let loaded = faultforge_fault::load_plugin(dir.path()).expect("shipped plugin loads");
+
+    let Some(coreutils_digest) = coreutils_sha256(&manifest_dst, &binary_dst) else {
+        eprintln!("skipping: neither sha256sum nor shasum is available");
+        return;
+    };
+    assert_eq!(
+        loaded.digest.as_str(),
+        coreutils_digest,
+        "load_plugin digest must reproduce `cat manifest.yaml disk-fill | sha256sum`"
+    );
+}

--- a/openspec/changes/add-disk-fill-plugin/.openspec.yaml
+++ b/openspec/changes/add-disk-fill-plugin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/add-disk-fill-plugin/design.md
+++ b/openspec/changes/add-disk-fill-plugin/design.md
@@ -1,0 +1,210 @@
+# Design: add-disk-fill-plugin
+
+## Context
+
+The fault pipeline is proven end to end, but only against `noop-marker`, whose "fault" is a
+marker file's existence. `disk-fill` (issue #62) is the first plugin whose injection genuinely
+mutates the host: it consumes free disk space. The revert stays trivial (`rm` one file), which
+is exactly why the Tier 1 epic (#18) recommends it as the first real plugin.
+
+Constraints inherited from the platform:
+
+- The `faultforge-fault` contract is fixed for this change: five argv commands, stdin
+  `PluginInput` JSON, NDJSON events on stdout, the 0/10/20/30 exit-code table. Params are a
+  closed schema of `string`/`int`/`bool`, every declared param required, no defaults (#85/#86
+  are deliberately deferred).
+- Plugins are sync binaries; no tokio/tonic, never the `proto` feature.
+- The agent re-verifies the catalog digest before every invocation and enforces an invocation
+  timeout (default 60s) per command.
+- Two-phase preflight: the machine invokes `preflight` twice per instance (`install` phase,
+  then `runtime`) with full params both times; `Phase` arrives in `PluginInput`.
+- Instance ids are validated at the agent boundary to `[A-Za-z0-9._:-]` with no `.`/`..`
+  components, so they are safe filename fragments on Linux filesystems.
+- Journal replay after an agent restart issues `abort` + `cleanup` (never `inject`), so revert
+  must be idempotent and must succeed from `(instance_id, params)` alone.
+- De-facto preflight rule (pinned by `noop-marker`, pending doc reconciliation in #35):
+  transient probes (create-and-remove) are allowed; persistent mutations are not.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A production-quality `disk-fill` plugin crate (`crates/plugins/disk-fill`, bin `disk-fill`)
+  implementing the full five-command contract with golden tests, mirroring `noop-marker`'s
+  test discipline.
+- Never wedge a host: a hard headroom guarantee (the plugin refuses to fill a filesystem to
+  100%), truthful `ABORTED`/"host unaffected" semantics on inject failure, revert that cannot
+  fail into taint under normal filesystem semantics.
+- E2e coverage in `crates/e2e` driving the real plugin through master → agent → host, with
+  ground truth observed via `podman exec`.
+
+**Non-Goals:**
+
+- Write-IO generation (`dd`-style load) — that is `io-stress` (#67); this plugin prefers
+  allocation without IO.
+- A root-filesystem opt-in guard (`fill_dir` on `/` refused unless opted in) — wants optional
+  params (#85); recorded as a known limitation instead.
+- Multiple fill files, percentage-based sizing, or recurring re-fill — out of scope for T1.
+- Any change to `crates/fault`, the agent runtime, the master, or the wire protocol.
+
+## Decisions
+
+### D1 — Allocation: `fallocate(2)` first, chunked write loop as documented fallback
+
+`fallocate(2)` allocates real blocks instantly with no write IO — the exact "pure space
+exhaustion" the issue asks for. Not every filesystem supports it (some network and exotic
+filesystems return `EOPNOTSUPP`/`EINVAL`), and the e2e containers must work regardless of the
+storage driver backing the volume, so on those errnos the plugin falls back to appending
+zeroed chunks (8 MiB buffer) until the target size is reached, then `fsync`s. The fallback is
+reported via a `log` event so an operator can tell which mechanism ran.
+
+Alternatives considered:
+
+- `ftruncate`/sparse file — rejected: allocates nothing, the disk never actually fills.
+- `posix_fallocate` — rejected: glibc silently emulates unsupported filesystems with a slow
+  byte-per-block write; we want the fallback explicit, observable, and chunked.
+- write loop only — rejected: needless IO and wall-clock on the 99% case; a large fill could
+  hit the agent's invocation timeout for no reason.
+
+Consequence of the invocation timeout: on a no-`fallocate` filesystem, very large fills may
+not complete within the agent's 60s budget. Documented in the manifest description; the
+fallback exists for container/e2e-sized fills, not multi-terabyte ones.
+
+**Allocation is verified, not trusted.** Some filesystems (notably FUSE-backed and network
+ones) return success from `fallocate` without actually reserving blocks. After allocating —
+by either mechanism — inject `fstat`s the file and requires `st_blocks × 512 >= size`;
+a shortfall is treated as an allocation failure (unlink + exit 20). `st_size` alone proves
+nothing: a sparse file has the right size and consumes no space, which would make the fault a
+silent no-op.
+
+### D2 — State tag: the fill file itself at a deterministic, id-derived path
+
+`<fill_dir>/faultforge-<instance_id>.fill`. The path is recomputable from
+`(instance_id, params)` alone, which makes cold-start revert trivial: `abort` and `cleanup`
+both remove exactly that path, and an absent file is success (idempotent, replay-safe).
+
+Because the filename *embeds the instance id*, ownership is established by construction —
+unlike `noop-marker`, where the operator chooses `marker_path` and cross-instance confusion is
+possible (issue #34). No content inspection is needed or useful (a `fallocate`d file has no
+meaningful content): `report` checks existence only — present → `ACTIVE`, absent → `DONE`.
+`abort`/`cleanup` remove the path unconditionally; any file at that exact name is ours by
+construction.
+
+### D3 — Safety headroom: hardcoded `max(5% of capacity, 64 MiB)`
+
+Preflight (runtime phase) refuses with exit 10 unless
+`available >= size_mib + max(capacity/20, 64 MiB)`. A percentage scales the guarantee to big
+disks; the 64 MiB floor keeps it meaningful on small ones (and keeps small e2e volumes
+usable). The headroom cannot be a param: the schema has no optional/defaulted params, and
+making every operator pass a safety constant invites `headroom: 0`. The constant and formula
+are documented in the manifest description.
+
+Space is measured with `statvfs`'s `f_bavail` (blocks available to unprivileged users), not
+`f_bfree`: it is the conservative bound and stays correct whether the plugin runs as root or
+not.
+
+Alternatives: required `headroom_mib` param (rejected — safety constants must not be
+operator-erasable); fixed 512 MiB (rejected — unusable on small filesystems, weak on 10 TiB
+ones).
+
+### D4 — Two-phase preflight split: static in `install`, host probes in `runtime`
+
+- `install` phase: pure param validation — `size_mib >= 1`, checked `size_mib × 1 MiB`
+  arithmetic (overflow → exit 10), `fill_dir` absolute, and the composed fill path stays a
+  direct child of `fill_dir` (defense in depth on top of the agent's id charset guarantee).
+- `runtime` phase: everything from `install`, plus `fill_dir` exists and is a directory,
+  writability via a transient probe (the honest check under ACLs, per the `noop-marker`
+  precedent and the direction of #35), and the D3 headroom check.
+
+The probe prefers `O_TMPFILE`: an anonymous file that never has a name in the directory and
+vanishes with its descriptor, so a crashed preflight cannot leak it. Filesystems without
+`O_TMPFILE` support fall back to `O_EXCL` create of a unique
+`.faultforge-probe-<instance_id>` name, unlinked immediately after open (so even on the
+fallback path the window for a leak is the syscall pair, not the whole command). Either way
+the probe is the only host touch preflight makes.
+
+**tmpfs is flagged, not refused.** Filling tmpfs consumes RAM, not disk — an operator
+pointing `fill_dir` at `/tmp` on a tmpfs distro would silently get a memory fault instead of
+a disk fault. Runtime preflight checks the filesystem's `statfs` `f_type` and emits a `warn`
+`log` event when it is `TMPFS_MAGIC`. A warning, not exit 10: filling tmpfs deliberately is a
+legitimate experiment; doing it unknowingly is the footgun, and the event removes the
+"unknowingly".
+
+### D5 — Inject hygiene: `O_EXCL` create, unlink on any failure past create
+
+`inject` creates the fill file with `O_CREAT|O_EXCL`. The agent guarantees inject is issued at
+most once per instance (duplicate `RunFault` ids are dropped; replay never re-injects), so a
+pre-existing file at the tag path is an anomaly: inject exits 20 **without** unlinking it.
+
+After a successful create, any failure (ENOSPC mid-allocation — the preflight check is
+inherently TOCTOU — fallocate errno, write-loop error) unlinks the partial file before exiting
+20. This keeps the machine's `ABORTED` reason "inject failed; host unaffected" truthful, which
+matters: an inject failure kill-switches the whole experiment, and the operator must be able
+to trust that the host needs no manual cleanup.
+
+### D6 — Syscall access via `rustix`
+
+`fallocate` and `statvfs` need a syscall crate. `rustix` provides safe, direct wrappers
+(`rustix::fs::fallocate`, `rustix::fs::statvfs`) with no `unsafe` in our code, which keeps the
+pedantic-clippy, no-unsafe posture of the workspace. Alternatives: raw `libc` (rejected:
+`unsafe` blocks in a safety-critical plugin), `nix` (workable, but `rustix` is the leaner
+dependency for exactly two calls).
+
+### D7 — Revert failure semantics
+
+`abort`/`cleanup`: `remove_file` where `ENOENT` is success; any other error (e.g. `EROFS`,
+permission loss) is a real removal failure → exit 30, which lets the agent's
+retry-cleanup-once-then-taint policy do its job. No retry logic inside the plugin — retry
+ownership belongs to the runtime (ADR-0002).
+
+### D8 — E2e scenarios extend the existing harness patterns
+
+Four scenarios in `crates/e2e/tests/scenarios.rs` (all `#[ignore]`, rootless podman), reusing
+the existing topology/wait helpers with the fill path under the agent's data volume:
+
+1. **Happy path** — submit with `--wait`; while `ACTIVE`, `podman exec stat` shows the fill
+   file at the exact expected byte size; after `COMPLETED` (exit 0) the file is gone.
+2. **Operator halt** — halt while `ACTIVE`; experiment `ABORTED`, file removed.
+3. **Preflight refusal** — `size_mib` far beyond the container filesystem's free space;
+   experiment ends `ABORTED` (`--wait` exit 4), and the fill file never existed.
+4. **Crash replay** — kill the agent container while `ACTIVE`, restart it; journal replay
+   removes the file before reconnect completes.
+
+`containers/Containerfile` builds `disk-fill` alongside `noop-marker` and installs it into the
+image's plugin catalog (same layout + sha256 digest flow).
+
+## Risks / Trade-offs
+
+- **[TOCTOU on free space]** Space can vanish between preflight and inject → D5 unlinks the
+  partial file and exits 20; the experiment aborts loudly with the host untouched.
+- **[Fallback write loop vs 60s invocation timeout]** On no-`fallocate` filesystems a huge
+  fill can time out; the agent kills the invocation and the machine recovers →
+  documented limitation; the runtime's recover path removes the partial file via
+  `abort`/`cleanup` (absent-or-present, removal is idempotent).
+- **[Concurrent fills on one filesystem]** Two instances can each pass preflight and jointly
+  breach the headroom → accepted for T1; blast-radius coordination is a master-side concern
+  (#61), not a plugin-side one. The headroom still bounds each single instance.
+- **[`:` in filenames]** Instance ids contain `:` (`<exp>:<host>:<idx>`), which is legal on
+  Linux filesystems but hostile to FAT/exFAT → accepted: agents target bare-metal Linux; the
+  data dir and fill dirs are expected to be native filesystems.
+- **[Headroom formula is a constant]** Some operator will want to fill closer to the edge →
+  deliberate: a safety constant that params cannot erase. Revisit only with #85 (optional
+  params) and a conscious opt-in design.
+- **[btrfs/ZFS space accounting]** `statvfs` on btrfs is approximate under RAID profiles
+  (free space depends on the profile of future allocations), and ZFS reports pool-level
+  numbers that CoW semantics can invalidate; ZFS also lacks `fallocate` entirely (the write
+  loop covers allocation, and the D1 `st_blocks` verification catches CoW filesystems where
+  even written blocks may not be accounted as expected) → accepted and documented in the
+  manifest description as a known limitation: on CoW filesystems the headroom check is best
+  effort. Not fixable plugin-side; the honest move is saying so.
+
+## Migration Plan
+
+Purely additive: a new workspace member and new catalog entries. No deploy or rollback steps
+beyond including/excluding the plugin directory from a host's catalog. Nothing existing
+changes behaviour.
+
+## Open Questions
+
+None — the headroom formula (D3) and the fallback policy (D1) are the two judgment calls, and
+both are decided above; revisit them only if e2e sizing proves awkward.

--- a/openspec/changes/add-disk-fill-plugin/proposal.md
+++ b/openspec/changes/add-disk-fill-plugin/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: add-disk-fill-plugin
+
+## Why
+
+FaultForge's entire fault pipeline (contract, agent runtime, master dispatch, e2e harness) has
+so far been proven only against `noop-marker`, a fault with zero blast radius. `disk-fill`
+(GitHub issue #62) is the designated first *real* fault: it consumes disk space — a genuine
+host mutation — while keeping the gentlest possible revert (`rm` one file). It is the
+recommended Tier 1 entry point ("build order: disk-fill → cpu-load → process-kill") and has no
+prerequisites: it needs no shared helper (#82) and no contract extension (#83–#87) — the issue's
+"fits existing types" claim holds against the current `faultforge-fault` schema.
+
+## What Changes
+
+- New crate `crates/plugins/disk-fill` (bin `disk-fill`): a fault plugin that allocates a file
+  of `size_mib` MiB inside `fill_dir` to consume free space, modelling a full disk.
+- Follows the `noop-marker` pattern: sync, depends only on `faultforge-fault` (never the
+  `proto` feature), manifest + golden tests pin the wire behaviour.
+- Deterministic state tag: the fill file itself at `<fill_dir>/faultforge-<instance_id>.fill`;
+  `abort`/`cleanup` remove exactly that path, absent = success (idempotent, replay-safe).
+- Allocation via `fallocate(2)` (instant, no write IO); documented fallback to a chunked write
+  loop when the filesystem does not support it (tmpfs/overlayfs in containers, and the e2e
+  suite, need this).
+- Safety headroom: preflight refuses (exit 10) unless free space ≥ `size_mib` + a hardcoded
+  headroom, so the plugin can never fill a filesystem to 100%.
+- Inject-failure hygiene: a partially allocated file is unlinked before exiting 20, keeping the
+  runtime's "inject failed; host unaffected" `ABORTED` reason truthful.
+- New e2e scenarios in `crates/e2e` driving the real disk-fill plugin through the operator
+  surface, with host ground truth via `podman exec`; the plugin is added to the container
+  image's plugin catalog in `containers/Containerfile`.
+
+Out of scope (documented as such): write-IO generation (`io-stress`, #67), an opt-in guard
+refusing `fill_dir` on the root filesystem (wants optional params, #85), any contract changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `disk-fill-plugin`: the disk-fill fault plugin — manifest, params, two-phase preflight,
+  fallocate-or-fallback inject, ownership-aware report, idempotent abort/cleanup, safety
+  headroom.
+
+### Modified Capabilities
+
+- `fault-e2e-harness`: the suite grows a requirement to cover a real host-mutating fault
+  (disk-fill) end to end — happy path, halt, preflight refusal, crash-replay — alongside the
+  existing noop-marker lifecycle scenarios.
+
+## Impact
+
+- **New code**: `crates/plugins/disk-fill` (workspace member), its `manifest.yaml`, golden +
+  manifest tests.
+- **Modified**: `Cargo.toml` (workspace members), `containers/Containerfile` (build + install
+  the plugin into the image catalog), `crates/e2e/tests/scenarios.rs` (new scenarios),
+  `CLAUDE.md` crate table.
+- **No changes** to `crates/fault`, `crates/agent`, `crates/master`, `crates/proto`, or the
+  wire protocol.
+- **Dependencies**: the plugin gains a `libc` (or `nix`) dependency for `fallocate(2)`/
+  `statvfs(3)`; no async runtime, no tonic.
+- **GitHub**: implements issue #62 under epic #18.

--- a/openspec/changes/add-disk-fill-plugin/specs/disk-fill-plugin/spec.md
+++ b/openspec/changes/add-disk-fill-plugin/specs/disk-fill-plugin/spec.md
@@ -1,0 +1,196 @@
+# Spec: disk-fill Plugin
+
+## Purpose
+
+Defines `disk-fill`, the first host-mutating fault plugin: it consumes free space on a target
+filesystem by allocating a single file, modelling a full disk. The blast radius is one file at
+a deterministic path; revert is its removal. The plugin guarantees it can never fill a
+filesystem to 100%.
+
+## ADDED Requirements
+
+### Requirement: disk-fill ships a fixed manifest and follows the plugin contract
+
+The catalog SHALL include a plugin named `disk-fill`, version `1`, entrypoint `./disk-fill`,
+`params_schema` of exactly `fill_dir: string` (an absolute directory path) and
+`size_mib: int`, `requires` declaring no binaries, no privileges, and the single precondition
+`fill_dir_writable`, and a `max_duration_secs` limit. The plugin SHALL be buildable from the
+workspace (`crates/plugins/disk-fill`) with its `manifest.yaml` alongside, SHALL depend only on
+the `faultforge-fault` contract crate (never its `proto` feature, no async runtime), and SHALL
+implement all five lifecycle commands with the contract's stdin/stdout/exit-code protocol.
+
+#### Scenario: Shipped manifest conforms to the contract
+
+- **WHEN** the shipped `manifest.yaml` is parsed and validated by the shared contract crate
+- **THEN** it SHALL parse without unknown fields and declare exactly the identity, entrypoint,
+  params schema, requirements, and duration limit above
+
+### Requirement: The fill file is the state tag at a deterministic id-derived path
+
+The fault's entire host effect SHALL be one file at
+`<fill_dir>/faultforge-<instance_id>.fill`. The path SHALL be recomputed from
+`(instance_id, params)` alone on every invocation — no breadcrumb, no plugin-side state — so
+that a cold-start `abort`/`cleanup` (journal replay) can revert without any memory of the
+inject.
+
+#### Scenario: Path is stable across invocations
+
+- **WHEN** any two lifecycle commands run with the same `instance_id` and `fill_dir`
+- **THEN** both SHALL resolve the same fill-file path, a direct child of `fill_dir`
+
+### Requirement: preflight validates statically in install phase and probes the host in runtime phase
+
+In both phases `preflight` SHALL fail with exit `10` (after a `log` event naming the reason)
+when `size_mib < 1`, when the byte size `size_mib × 1048576` overflows checked 64-bit
+arithmetic, or when `fill_dir` is not an absolute path. In the `runtime` phase it SHALL
+additionally fail with exit `10` when `fill_dir` does not exist or is not a directory, when a
+file already exists at the fill path (a leftover surfaces as a loud precondition failure
+instead of a mid-experiment inject failure), when `fill_dir` is not writable by the current
+uid — verified by an honest write probe, not by permission bits — or when the headroom
+requirement (below) is not met. The probe SHALL be
+un-leakable by construction: an anonymous `O_TMPFILE` file where the filesystem supports it,
+otherwise an exclusively created probe file unlinked immediately after open, so a crashed
+preflight leaves nothing named behind. In the `runtime` phase `preflight` SHALL also emit a
+`warn`-level `log` event when the target filesystem is tmpfs (filling tmpfs consumes memory,
+not disk); this SHALL NOT affect the exit code. On success it SHALL emit `status: PREFLIGHT`
+and exit `0`. Apart from the transient probe, `preflight` SHALL NOT mutate the host in either
+phase, and SHALL NOT create the fill file.
+
+#### Scenario: Install phase is static only
+
+- **WHEN** `preflight` runs with `phase: install` and well-formed params
+- **THEN** it SHALL exit `0` without touching `fill_dir` at all
+
+#### Scenario: Missing fill_dir is a runtime precondition failure
+
+- **WHEN** `preflight` runs with `phase: runtime` and `fill_dir` does not exist
+- **THEN** it SHALL emit a `log` event and exit `10`, and no fill file SHALL exist afterwards
+
+#### Scenario: Unwritable fill_dir is a runtime precondition failure
+
+- **WHEN** `fill_dir` exists but the probe-file write fails
+- **THEN** `preflight` SHALL emit a `log` event and exit `10`
+
+#### Scenario: Successful runtime preflight leaves no trace
+
+- **WHEN** `preflight` succeeds with `phase: runtime`
+- **THEN** it SHALL emit `status: PREFLIGHT`, exit `0`, and neither the probe file nor the
+  fill file SHALL exist
+
+#### Scenario: tmpfs target is warned about, not refused
+
+- **WHEN** `preflight` runs with `phase: runtime` and `fill_dir` resides on tmpfs
+- **THEN** it SHALL emit a `warn` `log` event naming the memory-not-disk consequence and
+  otherwise proceed with the normal checks and exit code
+
+### Requirement: The headroom guarantee prevents filling a filesystem to 100%
+
+`preflight` (runtime phase) SHALL refuse with exit `10` unless the target filesystem reports
+`available >= size_mib × 1048576 + headroom`, where `headroom = max(capacity / 20, 64 MiB)`
+(5% of capacity with a 64 MiB floor). Availability SHALL be measured as blocks available to
+unprivileged users (`f_bavail`), not total free blocks. The headroom SHALL NOT be
+operator-configurable.
+
+#### Scenario: Fill that would breach headroom is refused
+
+- **WHEN** the filesystem has free space greater than `size_mib` but less than
+  `size_mib + headroom`
+- **THEN** `preflight` SHALL emit a `log` event naming the shortfall and exit `10`
+
+#### Scenario: Fill within headroom is allowed
+
+- **WHEN** available space is at least `size_mib + headroom`
+- **THEN** `preflight` SHALL exit `0`
+
+### Requirement: inject allocates the fill file and leaves nothing behind on failure
+
+`inject` SHALL create the fill file with create-exclusive semantics and allocate exactly
+`size_mib × 1048576` bytes, preferring `fallocate(2)`; when the filesystem does not support
+`fallocate`, it SHALL fall back to appending zeroed chunks until the target size is reached,
+announcing the fallback via a `log` event. Allocation SHALL be verified, not trusted: after
+allocating by either mechanism, `inject` SHALL require the file's block usage
+(`st_blocks × 512`) to be at least the requested byte size, and SHALL treat a shortfall as an
+allocation failure — a sparse or unreserved file would make the fault a silent no-op. On
+success it SHALL emit `status: INJECTING` then `status: ACTIVE` and exit `0`, the process
+exiting immediately — the fault's active state SHALL be purely the allocated file's
+existence. If the file already exists, `inject` SHALL emit a `log` event and exit `20`
+without removing it. On any failure after creating the file (including `ENOSPC` from the
+preflight-to-inject race and the block-usage verification), it SHALL remove the partial file
+before exiting `20`, so that exit `20` always means the host is unaffected.
+
+#### Scenario: Successful allocation
+
+- **WHEN** `inject` succeeds
+- **THEN** the fill file SHALL exist at the deterministic path with exactly the requested byte
+  size and with block usage covering it, and stdout SHALL contain `INJECTING` followed by
+  `ACTIVE` status events
+
+#### Scenario: Unbacked allocation is a failure, not a silent no-op
+
+- **WHEN** the filesystem reports allocation success but the file's block usage does not
+  cover the requested size
+- **THEN** `inject` SHALL emit a `log` event, remove the file, and exit `20`
+
+#### Scenario: Allocation failure removes the partial file
+
+- **WHEN** allocation fails partway (e.g. the filesystem runs out of space mid-fill)
+- **THEN** `inject` SHALL emit a `log` event and exit `20`, and no fill file (partial or
+  otherwise) SHALL remain
+
+#### Scenario: Pre-existing fill file is refused, not clobbered
+
+- **WHEN** a file already exists at the fill path when `inject` runs
+- **THEN** `inject` SHALL emit a `log` event and exit `20`, and the existing file SHALL be
+  untouched
+
+### Requirement: report is a read-only existence probe
+
+`report` SHALL emit `status: ACTIVE` when the fill file exists and `status: DONE` when it does
+not, exiting `0` in both cases, and SHALL NOT create, modify, or remove anything. Ownership is
+established by the id-derived filename; `report` SHALL NOT inspect file content.
+
+#### Scenario: Present fill file reports ACTIVE
+
+- **WHEN** `report` runs while the fill file exists
+- **THEN** it SHALL emit `status: ACTIVE` and exit `0`
+
+#### Scenario: Absent fill file reports DONE
+
+- **WHEN** `report` runs and the fill file does not exist
+- **THEN** it SHALL emit `status: DONE` and exit `0`
+
+### Requirement: abort and cleanup remove the fill file idempotently
+
+`abort` and `cleanup` SHALL remove the fill file at the deterministic path, treating an
+already-absent file as success (`abort` emits `status: RECOVERING` then `status: DONE`;
+`cleanup` emits `status: DONE`), and exit `0`. A real removal failure (any error other than
+absence) SHALL emit a `log` event and exit `30`, leaving retry-then-taint to the agent
+runtime. Neither command SHALL touch any other path.
+
+#### Scenario: Cleanup twice in a row is success twice
+
+- **WHEN** `cleanup` runs twice consecutively
+- **THEN** both invocations SHALL exit `0` and the fill file SHALL NOT exist afterwards
+
+#### Scenario: Abort removes the fill file
+
+- **WHEN** `abort` runs while the fill file exists
+- **THEN** the file SHALL be removed and the command SHALL exit `0`
+
+#### Scenario: Real removal failure is exit 30
+
+- **WHEN** removal fails for a reason other than the file being absent
+- **THEN** the command SHALL emit a `log` event and exit `30`
+
+### Requirement: disk-fill's host effects are confined to the fill directory
+
+Across all five commands, the plugin SHALL create or remove only the fill file and the
+transient preflight probe, both residing directly in `fill_dir` (the probe is anonymous or
+immediately unlinked). It SHALL NOT write outside `fill_dir`, SHALL NOT follow the composed
+path out of `fill_dir` (path traversal), and SHALL NOT spawn processes or touch host
+services.
+
+#### Scenario: Filesystem effects are confined to fill_dir
+
+- **WHEN** any lifecycle command runs
+- **THEN** every path the plugin creates or removes SHALL be a direct child of `fill_dir`

--- a/openspec/changes/add-disk-fill-plugin/specs/fault-e2e-harness/spec.md
+++ b/openspec/changes/add-disk-fill-plugin/specs/fault-e2e-harness/spec.md
@@ -1,0 +1,42 @@
+# Delta: fault-e2e-harness — real-fault (disk-fill) coverage
+
+## ADDED Requirements
+
+### Requirement: The suite covers a real host-mutating fault end to end
+
+Beyond the noop-marker lifecycle scenarios, the suite SHALL drive the `disk-fill` plugin — a
+fault whose injection genuinely mutates the host filesystem — through the operator surface,
+asserting host ground truth via `podman exec` against the agent container. The `disk-fill`
+binary and manifest SHALL be installed into the container image's plugin catalog by the same
+image build (`containers/Containerfile`) that installs `noop-marker`. The scenarios SHALL
+cover at least:
+
+1. **Happy path**: an experiment fills a directory on the agent's data volume; while the
+   instance is `ACTIVE` the fill file exists at its deterministic path with exactly the
+   requested byte size; after `COMPLETED` (CLI `--wait` exit `0`) the file is gone.
+2. **Operator halt**: halting the experiment while `ACTIVE` ends it `ABORTED` and removes the
+   fill file.
+3. **Preflight refusal**: a `size_mib` far beyond the container filesystem's free space ends
+   the experiment `ABORTED` (CLI `--wait` exit `4`) and the fill file never existed.
+4. **Crash replay**: killing and restarting the agent container while `ACTIVE` replays the
+   journal and removes the fill file.
+
+#### Scenario: Fill file is host ground truth for the active window
+
+- **WHEN** the happy-path scenario observes the instance `ACTIVE`
+- **THEN** `podman exec` SHALL confirm the fill file exists with exactly
+  `size_mib × 1048576` bytes, and after the experiment reports `COMPLETED` it SHALL confirm
+  the file is absent
+
+#### Scenario: Refused preflight leaves the host untouched
+
+- **WHEN** the preflight-refusal scenario completes
+- **THEN** the experiment SHALL end `ABORTED` with CLI exit `4` and `podman exec` SHALL
+  confirm no fill file was ever created
+
+#### Scenario: Replay reverts the real fault
+
+- **WHEN** the agent container is killed while a disk-fill instance is `ACTIVE` and then
+  restarted
+- **THEN** journal replay SHALL remove the fill file and the experiment SHALL reach a
+  terminal outcome

--- a/openspec/changes/add-disk-fill-plugin/tasks.md
+++ b/openspec/changes/add-disk-fill-plugin/tasks.md
@@ -62,7 +62,7 @@
 ## 5. Docs & bookkeeping
 
 - [x] 5.1 Update `CLAUDE.md` crate table with `crates/plugins/disk-fill`
-- [ ] 5.2 Reference issue #62 in the PR; note the known limitations (no root-fs opt-in guard
+- [x] 5.2 Reference issue #62 in the PR; note the known limitations (no root-fs opt-in guard
       pending #85; fallback write loop vs the 60s invocation timeout; best-effort headroom on
       CoW filesystems — btrfs RAID-profile `statvfs` fuzziness, ZFS pool-level accounting and
       missing `fallocate`)

--- a/openspec/changes/add-disk-fill-plugin/tasks.md
+++ b/openspec/changes/add-disk-fill-plugin/tasks.md
@@ -1,0 +1,68 @@
+# Tasks: add-disk-fill-plugin
+
+## 1. Crate scaffolding
+
+- [x] 1.1 Create `crates/plugins/disk-fill` (bin `disk-fill`) mirroring the `noop-marker`
+      layout; add to workspace members; deps: `faultforge-fault` (no `proto` feature),
+      `serde_json`, `rustix` (fs feature)
+- [x] 1.2 Write `manifest.yaml`: `disk-fill@1`, entrypoint `./disk-fill`, params
+      `fill_dir: string` + `size_mib: int`, precondition `fill_dir_writable`,
+      `max_duration_secs`; document the headroom formula and the fallocate-fallback in the
+      manifest description
+- [x] 1.3 Manifest test (as `noop-marker`'s `tests/manifest.rs`): shipped manifest parses and
+      validates against the shared contract crate
+
+## 2. Plugin core
+
+- [x] 2.1 Argv/stdin shell: parse the five commands, read `PluginInput`, defense-in-depth
+      re-validation of params (as `noop-marker` does), deterministic fill-path derivation
+      `<fill_dir>/faultforge-<instance_id>.fill` with a containment check (direct child of
+      `fill_dir`)
+- [x] 2.2 `preflight`: install phase static checks (`size_mib >= 1`, checked byte-size
+      arithmetic, absolute `fill_dir`); runtime phase adds dir-exists/is-dir, un-leakable
+      writability probe (`O_TMPFILE`, fallback `O_EXCL` create + immediate unlink), the
+      `statvfs` headroom check (`f_bavail`, `headroom = max(capacity/20, 64 MiB)`) — exit 10
+      with a `log` event on each failure — and a `warn` `log` event (not a refusal) when
+      `statfs` `f_type` is `TMPFS_MAGIC`
+- [x] 2.3 `inject`: `O_CREAT|O_EXCL` create (pre-existing file → log + exit 20, untouched);
+      `rustix::fs::fallocate`, on `EOPNOTSUPP`/`EINVAL` fall back to chunked zero-writes
+      (8 MiB) + fsync with a `log` event announcing the fallback; verify allocation is real
+      (`st_blocks × 512 >= size`, shortfall = failure); any failure after create unlinks the
+      partial file before exit 20; success emits `INJECTING` then `ACTIVE`
+- [x] 2.4 `report`: existence-only probe — exists → `ACTIVE`, absent → `DONE`, exit 0, no
+      mutations
+- [x] 2.5 `abort`/`cleanup`: remove the fill path, `ENOENT` = success (abort emits
+      `RECOVERING`→`DONE`, cleanup `DONE`), other errors → log + exit 30
+
+## 3. Golden tests
+
+- [x] 3.1 Golden tests (as `noop-marker`'s `tests/golden.rs`) pinning: happy lifecycle
+      (preflight install/runtime → inject → report ACTIVE → cleanup → report DONE), exact
+      allocated size **and** block usage (`st_blocks` covers the request — sparse files must
+      fail), cleanup idempotence, pre-existing-file refusal, partial-file removal on
+      allocation failure, preflight refusals (relative dir, missing dir, unwritable dir,
+      `size_mib < 1`, headroom breach), no probe residue after a runtime preflight, tmpfs
+      `warn` event on a tmpfs-backed temp dir, traversal-hostile `fill_dir`/id handling
+- [x] 3.2 `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check`
+      clean
+
+## 4. E2e coverage
+
+- [x] 4.1 Extend `containers/Containerfile`: build `disk-fill` and install bin + manifest +
+      sha256 digest into the image plugin catalog next to `noop-marker`
+- [x] 4.2 Scenario: happy path — fill under the agent data volume, `podman exec stat` asserts
+      exact byte size while `ACTIVE`, file gone after `COMPLETED` (`--wait` exit 0)
+- [x] 4.3 Scenario: operator halt while `ACTIVE` → experiment `ABORTED`, file removed
+- [x] 4.4 Scenario: preflight refusal — absurd `size_mib` → `ABORTED` (`--wait` exit 4), fill
+      file never created
+- [x] 4.5 Scenario: crash replay — kill+restart agent container while `ACTIVE`, journal
+      replay removes the file, experiment reaches a terminal outcome
+- [x] 4.6 Run `cargo test -p faultforge-e2e -- --ignored` green under rootless podman
+
+## 5. Docs & bookkeeping
+
+- [x] 5.1 Update `CLAUDE.md` crate table with `crates/plugins/disk-fill`
+- [ ] 5.2 Reference issue #62 in the PR; note the known limitations (no root-fs opt-in guard
+      pending #85; fallback write loop vs the 60s invocation timeout; best-effort headroom on
+      CoW filesystems — btrfs RAID-profile `statvfs` fuzziness, ZFS pool-level accounting and
+      missing `fallocate`)


### PR DESCRIPTION
Implements #62 (Tier 1, epic #18) — the first plugin whose injection genuinely mutates the host, per the epic's recommended build order.

## What

New crate `crates/plugins/disk-fill` (bin `disk-fill`), following the `noop-marker` pattern: sync, `faultforge-fault` contract only (no `proto` feature, no async runtime), golden + manifest tests.

- **Deterministic state tag**: the fill file itself at `<fill_dir>/faultforge-<instance_id>.fill` — recomputable from `(instance_id, params)` alone, so cold-start revert (journal replay) needs no breadcrumb. Ownership is by construction: the filename embeds the instance id.
- **Allocation**: `fallocate(2)` (instant, no write IO); chunked-write fallback on `EOPNOTSUPP`/`EINVAL`, announced via a `log` event. **Verified, not trusted**: after allocating, `st_blocks × 512` must cover the requested size — a sparse/unbacked fill fails loudly instead of becoming a silent no-op fault.
- **Hard headroom guarantee**: runtime preflight refuses (exit 10) unless `available ≥ size + max(capacity/20, 64 MiB)` (`f_bavail`, the conservative bound). Deliberately not a param — a safety constant operators cannot erase.
- **Inject hygiene**: `O_CREAT|O_EXCL` (a pre-existing file is refused, never clobbered); any failure after create unlinks the partial file before exit 20, keeping the runtime's "inject failed; host unaffected" `ABORTED` reason truthful — this matters because an inject failure kill-switches the whole experiment.
- **Un-leakable preflight probe**: `tempfile_in` (`O_TMPFILE` on Linux, create+immediate-unlink elsewhere) — a crashed preflight leaves nothing named behind.
- **tmpfs is flagged, not refused**: filling tmpfs consumes RAM, not disk; runtime preflight emits a `warn` event so nobody does it *unknowingly*.

## E2e

Four new scenarios (all green locally alongside the existing six, `cargo test -p faultforge-e2e -- --ignored`): happy path with exact-size + block-backed host ground truth via `podman exec stat`, operator halt, preflight refusal (exbibyte request → `ABORTED`, `--wait` exit 4, host untouched), agent crash + journal replay. `containers/Containerfile` builds and installs `disk-fill@1` into the image catalog.

OpenSpec change `add-disk-fill-plugin` (proposal/design/specs/tasks) is included; the `disk-fill-plugin` spec is new, plus a delta on `fault-e2e-harness`.

## Known limitations (deliberate)

- No root-fs opt-in guard (`fill_dir` on `/`): wants optional params (#85).
- The fallback write loop can hit the agent's 60s invocation timeout for very large fills on no-`fallocate` filesystems; the runtime's recover path still removes the partial file.
- Headroom is best effort on CoW filesystems: btrfs `statvfs` is approximate under RAID profiles; ZFS reports pool-level numbers and lacks `fallocate` (the write loop + `st_blocks` verification cover it).
- Forced mid-allocation failure (real ENOSPC) has no hermetic golden test — the refusal/verification logic is unit-tested pure code (`headroom_allows`, `allocation_backed`) and the removal path is shared with the verified refusal branches.

## Verification

- `cargo test --workspace` ✓ (28 new tests: 7 unit, 19 golden, 2 manifest)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo fmt --check` ✓
- `cargo test -p faultforge-e2e -- --ignored` ✓ 10/10 under rootless podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)